### PR TITLE
Simplify jellyfin matching

### DIFF
--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"explo/src/config"
 	"explo/src/debug"
@@ -130,7 +129,7 @@ func (c *Jellyfin) RefreshLibrary() error {
 
 func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 	for _, track := range tracks {
-		queryParams := fmt.Sprintf("/Items?parentId=%s&fields=Path&mediaTypes=Audio&searchTerm=%s&recursive=true", c.LibraryID, url.QueryEscape(track.CleanTitle))
+		queryParams := fmt.Sprintf("/Items?parentId=%s&mediaTypes=Audio&searchTerm=%s&recursive=true", c.LibraryID, url.QueryEscape(track.CleanTitle))
 
 		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+queryParams, nil, c.Cfg.Creds.Headers)
 		if err != nil {
@@ -143,7 +142,7 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 		}
 
 		for _, item := range results.Items {
-			if track.MainArtist == item.AlbumArtist && strings.Contains(item.Path, track.CleanTitle) {
+			if track.MainArtist == item.AlbumArtist && item.Name == track.CleanTitle {
 				track.ID = item.ID
 				track.Present = true
 				break


### PR DESCRIPTION
Chalk it up to my relative unfamiliarity with github perhaps, but i completely missed the [second set of changes](https://github.com/LumePart/Explo/pull/22/files/f81b247d19f0c61554aa19ebd798628efc5f931a) on #22. 

This should address that by removing the path comparison and the path field from the jellyfin api call. Sorry for hassle!