### PR TITLE
Address lint failures; add lint job to PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches:
+      - dev
+  pull_request:
+    branches: ['*']
 
 name: Latest Release
 
@@ -18,9 +22,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.6'
+          go-version: '1.23'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@v8.0.0
         with:
           version: latest
   release:
@@ -41,7 +45,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.6'
+          go-version: '1.23'
       - name: Get OS and arch info
         run: |
           GOOSARCH=${{matrix.goosarch}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 # Set the working directory
 WORKDIR /app

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Videos struct {
-	Items   []Item `json:"items"`
+	Items []Item `json:"items"`
 }
 
 type ID struct {
@@ -26,8 +26,8 @@ type ID struct {
 }
 
 type Snippet struct {
-	Title                string     `json:"title"`
-	ChannelTitle         string     `json:"channelTitle"`
+	Title        string `json:"title"`
+	ChannelTitle string `json:"channelTitle"`
 }
 
 type Item struct {
@@ -37,19 +37,19 @@ type Item struct {
 
 type Youtube struct {
 	DownloadDir string
-	HttpClient *util.HttpClient
-	Cfg cfg.Youtube
+	HttpClient  *util.HttpClient
+	Cfg         cfg.Youtube
 }
 
 func NewYoutube(cfg cfg.Youtube, discovery, downloadDir string, httpClient *util.HttpClient) *Youtube { // init downloader cfg for youtube
 	return &Youtube{
 		DownloadDir: downloadDir,
-		Cfg: cfg,
-		HttpClient: httpClient}
+		Cfg:         cfg,
+		HttpClient:  httpClient}
 }
 
 func (c *Youtube) QueryTrack(track *models.Track) error { // Queries youtube for the song
-	
+
 	escQuery := url.PathEscape(fmt.Sprintf("%s - %s", track.Title, track.Artist))
 	queryURL := fmt.Sprintf("https://youtube.googleapis.com/youtube/v3/search?part=snippet&q=%s&type=video&videoCategoryId=10&key=%s", escQuery, c.Cfg.APIKey)
 
@@ -83,7 +83,7 @@ func (c *Youtube) GetTrack(track *models.Track) error {
 }
 
 func getTopic(cfg cfg.Youtube, videos Videos, track models.Track) string { // gets song under artist topic or personal channel
-	
+
 	for _, v := range videos.Items {
 		if (strings.Contains(v.Snippet.ChannelTitle, "- Topic") || v.Snippet.ChannelTitle == track.MainArtist) && filter(track, v.Snippet.Title, cfg.FilterList) {
 			return v.ID.VideoID
@@ -109,29 +109,38 @@ func getVideo(ctx context.Context, c Youtube, videoID string) (*goutubedl.Downlo
 	}
 
 	return downloadResult, nil
-			
+
 }
 
 func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) bool {
 
-	defer stream.Close()
+	defer func() {
+		if err := stream.Close(); err != nil {
+			log.Printf("warning: stream close failed: %v", err)
+		}
+	}()
 
 	input := fmt.Sprintf("%s%s_TEMP.mp3", c.DownloadDir, track.File)
 	file, err := os.Create(input)
 	if err != nil {
 		log.Fatalf("Failed to create song file: %s", err.Error())
 	}
-	defer file.Close()
+
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Printf("warning: file close failed: %v", err)
+		}
+	}()
 
 	if _, err = io.Copy(file, stream); err != nil {
 		log.Printf("Failed to copy stream to file: %s", err.Error())
-		os.Remove(input)
+		_ = os.Remove(input) //nolint:errcheck // best-effort cleanup
 		return false
 	}
 
 	cmd := ffmpeg.Input(input).Output(fmt.Sprintf("%s%s.mp3", c.DownloadDir, track.File), ffmpeg.KwArgs{
-		"map": "0:a",
-		"metadata": []string{"artist="+track.Artist,"title="+track.Title,"album="+track.Album},
+		"map":      "0:a",
+		"metadata": []string{"artist=" + track.Artist, "title=" + track.Title, "album=" + track.Album},
 		"loglevel": "error",
 	}).OverWriteOutput().ErrorToStdOut()
 
@@ -141,19 +150,19 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 
 	if err = cmd.Run(); err != nil {
 		log.Printf("Failed to convert audio: %s", err.Error())
-		os.Remove(input)
+		_ = os.Remove(input) //nolint:errcheck // best-effort cleanup
 		return false
 	}
-	os.Remove(input)
+	_ = os.Remove(input) //nolint:errcheck // best-effort cleanup
 	return true
 }
 
 func gatherVideo(cfg cfg.Youtube, videos Videos, track models.Track) string { // filter out video ID
-	
+
 	// Try to get the video from the official or topic channel
 	if id := getTopic(cfg, videos, track); id != "" {
 		return id
-			
+
 	}
 	// If official video isn't found, try the first suitable channel
 	for _, video := range videos.Items {
@@ -171,11 +180,11 @@ func fetchAndSaveVideo(ctx context.Context, cfg Youtube, track models.Track) boo
 		log.Printf("failed getting stream for video ID %s: %s", track.ID, err.Error())
 		return false
 	}
-	
+
 	if stream != nil {
 		return saveVideo(cfg, track, stream)
 	}
-	
+
 	log.Printf("stream was nil for video ID %s", track.ID)
 	return false
 }
@@ -183,7 +192,7 @@ func fetchAndSaveVideo(ctx context.Context, cfg Youtube, track models.Track) boo
 func filter(track models.Track, videoTitle string, filterList []string) bool { // ignore titles that have a specific keyword (defined in .env)
 
 	for _, keyword := range filterList {
-		if (!containsLower(track.Title,keyword) && !containsLower(track.Artist, keyword) && containsLower(videoTitle, keyword)) {
+		if !containsLower(track.Title, keyword) && !containsLower(track.Artist, keyword) && containsLower(videoTitle, keyword) {
 			return false
 		}
 	}
@@ -193,7 +202,7 @@ func filter(track models.Track, videoTitle string, filterList []string) bool { /
 func containsLower(str string, substr string) bool {
 
 	return strings.Contains(
-        strings.ToLower(str),
-        strings.ToLower(substr),
-    )
+		strings.ToLower(str),
+		strings.ToLower(substr),
+	)
 }

--- a/src/main.go
+++ b/src/main.go
@@ -12,9 +12,9 @@ import (
 )
 
 type Song struct {
-	Title string
+	Title  string
 	Artist string
-	Album string
+	Album  string
 }
 
 func initHttpClient() *util.HttpClient {
@@ -33,7 +33,10 @@ func main() {
 	cfg := config.ReadEnv()
 	setup(&cfg)
 	httpClient := initHttpClient()
-	client := client.NewClient(&cfg, httpClient)
+	client, err := client.NewClient(&cfg, httpClient)
+	if err != nil {
+		log.Fatal(err)
+	}
 	discovery := discovery.NewDiscoverer(cfg.DiscoveryCfg, httpClient)
 	downloader := downloader.NewDownloader(&cfg.DownloadCfg, httpClient)
 
@@ -57,6 +60,6 @@ func main() {
 	if err := client.CreatePlaylist(tracks); err != nil {
 		log.Println(err)
 	} else {
-		log.Printf("[%s] %s playlist created successfully",cfg.System, cfg.ClientCfg.PlaylistName)
+		log.Printf("[%s] %s playlist created successfully", cfg.System, cfg.ClientCfg.PlaylistName)
 	}
 }

--- a/src/util/http.go
+++ b/src/util/http.go
@@ -1,21 +1,22 @@
 package util
 
 import (
-	"net/http"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
+	"net/http"
 	"time"
 
 	"explo/src/debug"
 )
 
 type HttpClientConfig struct {
-	Timeout        time.Duration
+	Timeout time.Duration
 }
 
 type HttpClient struct {
-	Client         *http.Client
+	Client *http.Client
 }
 
 func NewHttp(cfg HttpClientConfig) *HttpClient {
@@ -31,24 +32,29 @@ func (c *HttpClient) MakeRequest(method, url string, payload io.Reader, headers 
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize request: %s", err.Error())
 	}
-	req.Header.Add("Content-Type","application/json")
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 
 	for key, value := range headers {
-		req.Header.Add(key,value)
+		req.Header.Add(key, value)
 	}
 
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %s", err.Error())
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("warning: response body close failed: %v", err)
+		}
+	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %s", err.Error())
 	}
-	
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("got %d from %s", resp.StatusCode, url)
 	}
@@ -57,7 +63,7 @@ func (c *HttpClient) MakeRequest(method, url string, payload io.Reader, headers 
 }
 
 func ParseResp[T any](body []byte, target *T) error {
-	
+
 	if err := json.Unmarshal(body, target); err != nil {
 		debug.Debug(fmt.Sprintf("full response: %s", string(body)))
 		return fmt.Errorf("error unmarshaling response body: %s", err.Error())


### PR DESCRIPTION
The lint job for the new dev tag failed with a deprecation warning as well as some unhandled errors. This PR bumps the linter version around the deprecation, handles or explicitly ignores the errors, and adds a lint job to PRs so they can be addressed before failing on dev/main