### PR TITLE
Add ARM support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
         goosarch:
           - 'linux/amd64'
           - 'linux/386'
+          - 'linux/arm64'
+          - 'linux/arm'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -110,7 +112,7 @@ jobs:
             ghcr.io/${{ env.REPO_LC }}:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/386
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7
           build-args: |
             TARGETARCH
 
@@ -153,6 +155,6 @@ jobs:
           tags: ghcr.io/${{ env.REPO_LC }}:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/386
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7
           build-args: |
             TARGETARCH


### PR DESCRIPTION
I personally use an arm server and would like to see a native package for it. I had previously attempted to set up podman virtualization on it, but the qemu package in the nixpkgs repository appears to have issues building on arm.

This is why I have opened a pull request that introduces native arm64 and arm v7 builds. I tried running my own fork and it seems to work without issues.