### PR TITLE
Add support for the Daily Jam mix

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -106,6 +106,7 @@ type Listenbrainz struct {
 	Discovery string `env:"LISTENBRAINZ_DISCOVERY" env-default:"playlist"`
 	User string `env:"LISTENBRAINZ_USER"`
 	SingleArtist bool `env:"SINGLE_ARTIST" env-default:"true"`
+	IncludeDaily bool   `env:"LISTENBRAINZ_INCLUDE_DAILY" env-default:"true"`
 }
 
 func ReadEnv() Config {


### PR DESCRIPTION
Add support for the daily Jam from ListenBrainz. It is enabled by default but can be turned off by setting `LISTENBRAINZ_INCLUDE_DAILY` to `false` in the config.

I have renamed the `parseWeekly` to be generic as it can be used to parse any LB playlist. I've assumed that a default `true` for the daily makes sense here as you will probably want both lists if you are using LB already.

I'm not a Golang expert so there may be some less idiomatic syntax in places. Please review and let me know if and what needs changing.

Fixes #12