### PR TITLE
fix(jellyfin): use Search/Hints endpoint for playlist lookup

### DIFF
--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -168,7 +168,7 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 }
 
 func (c *Jellyfin) SearchPlaylist() error {
-	queryParams := fmt.Sprintf("/Items?mediaTypes=Playlist&searchTerm=%s&recursive=true", c.Cfg.PlaylistName)
+	queryParams := fmt.Sprintf("/Search/Hints?IncludeItemTypes=Playlist&SearchTerm=%s", c.Cfg.PlaylistName)
 	body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+queryParams, nil, c.Cfg.Creds.Headers)
 	if err != nil {
 		return err


### PR DESCRIPTION
I was trying to use a non-persistent weekly playlist with a Jellyfin client, with the persist flag set to false and USE_SUBDIRECTORY set to true as documented. This currently seems to be broken because of how the playlist is looked up before deletion in the Jellyfin client SearchPlaylist function.

SearchPlaylist was querying /Items but parsing the response as SearchHints, which caused playlist lookup to fail even when the playlist exists.

This switches the request to /Search/Hints with IncludeItemTypes=Playlist so the response matches the existing parsing logic.

I’m not very familiar with the Jellyfin API, so please let me know if there’s a better approach that preserves the current SearchPlaylist implementation.

Edit:

Current Jellyfin playlist search api call:

curl -H "X-Emby-Token: <jellyfin_api_token>" "http://<jellyfin_url>/Items?mediaTypes=Playlist&searchTerm=Weekly-Exploration&recursive=true"

Fixed Jellyfin playlist search api call:

curl -H "X-Emby-Token: <jellyfin_api_token>" "http://<jellyfin_url>/Search/Hints?IncludeItemTypes=Playlist&SearchTerm=Weekly-Exploration"

