### PR TITLE
fix(youtube): Correctly build download path in youtube saveVideo function

### DIFF
--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	cfg "explo/src/config"
@@ -181,7 +182,7 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 		}
 	}()
 
-	input := fmt.Sprintf("%s%s.tmp", c.DownloadDir, track.File)
+	input := filepath.Join(c.DownloadDir, track.File+".tmp")
 	file, err := os.Create(input)
 	if err != nil {
 		slog.Error("failed to create song file", "context", err.Error())
@@ -202,7 +203,7 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 		return false
 	}
 
-	cmd := ffmpeg.Input(input).Output(fmt.Sprintf("%s%s", c.DownloadDir, track.File), ffmpeg.KwArgs{
+	cmd := ffmpeg.Input(input).Output(filepath.Join(c.DownloadDir, track.File), ffmpeg.KwArgs{
 		"map":      "0:a",
 		"metadata": []string{"artist=" + track.Artist, "title=" + track.Title, "album=" + track.Album},
 		"loglevel": "error",


### PR DESCRIPTION
Because of changes in [#8f9e10a ](https://github.com/LumePart/Explo/commit/8f9e10ae0213eb3c5f705a27fb20cd11134912fd) youtube downloads with USE_SUBDIRECTORY were written to the wrong path. DownloadDir no longer had a trailing slash, so string concatenation produced subdirname.ext instead of name.ext.