### PR TITLE
Support separate admin credentials for subsonic library scans

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -17,6 +17,10 @@ SYSTEM_URL=
 SYSTEM_USERNAME=
 # Password for the user (required for subsonic, recommended for plex)
 SYSTEM_PASSWORD=
+# Optional admin username for systems like Navidrome/Subsonic (used only for triggering library scans)
+# ADMIN_SYSTEM_USERNAME=
+# Optional admin password for systems like Navidrome/Subsonic (used only for triggering library scans)
+# ADMIN_SYSTEM_PASSWORD=
 # API Key from your media system (required for emby and jellyfin, optional for plex)
 API_KEY=
 # Name of the music library in your system (emby, jellyfin, plex)

--- a/src/client/subsonic.go
+++ b/src/client/subsonic.go
@@ -158,8 +158,22 @@ func (c *Subsonic) SearchSongs(tracks []*models.Track) error {
 }
 
 func (c *Subsonic) RefreshLibrary() error {
+	if c.Cfg.AdminCreds.User != "" && c.Cfg.AdminCreds.Password != "" {
+		adminCfg := c.Cfg
+		adminCfg.Creds = config.Credentials{User: c.Cfg.AdminCreds.User, Password: c.Cfg.AdminCreds.Password}
+		adminClient := NewSubsonic(adminCfg, c.HttpClient)
+
+		if err := adminClient.GetAuth(); err != nil {
+			return err
+		}
+		return adminClient.startScan()
+	}
+
+	return c.startScan()
+}
+
+func (c *Subsonic) startScan() error {
 	reqParam := "startScan?f=json"
-	
 	if _, err := c.subsonicRequest(reqParam); err != nil {
 		return err
 	}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -49,6 +49,7 @@ type ClientConfig struct {
 	Sleep int `env:"SLEEP" env-default:"2"`
 	HTTPTimeout int `env:"CLIENT_HTTP_TIMEOUT" env-default:"10"`
 	Creds Credentials
+	AdminCreds AdminCredentials
 	Subsonic SubsonicConfig
 }
 
@@ -59,6 +60,11 @@ type Credentials struct {
 	Headers map[string]string
 	Token string
 	Salt string
+}
+
+type AdminCredentials struct {
+	User string `env:"ADMIN_SYSTEM_USERNAME"`
+	Password string `env:"ADMIN_SYSTEM_PASSWORD"`
 }
 
 


### PR DESCRIPTION
Hey there, great project I modified it slightly for my usecase and thought this might also be useful for others. 
Details below:

 ## Summary                                                                                                                                                                                                                                               
  - Adds optional `ADMIN_SYSTEM_USERNAME` and `ADMIN_SYSTEM_PASSWORD` config options                                                                                                                                                                       
  - When provided, admin credentials are used to trigger library scans while playlists are created under the regular user account                                                                                                                          
                                                                                                                                                                                                                                                           
  ## Use case                                                                                                                                                                                                                                              
  Subsonic-compatible servers like Navidrome require admin privileges to trigger library scans. This allows non-admin users to have personalized playlists without needing admin access to the media server.
  My personal case is that I manage a Navidrome server for my family and I wanted to seutpo explo for each user to get their own playlist without all the accounts having admin rights.                                               
                                                                                                                                                                                                                                                           
  ## Changes                                                                                                                                                                                                                                               
  - `config.go`: Added `AdminCredentials` struct                                                                                                                                                                                                           
  - `subsonic.go`: `RefreshLibrary()` uses admin credentials for scans if provided                                                                                                                                                                         
  - `sample.env`: Documented new options            