### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           fetch-depth: 0
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -100,11 +100,11 @@ jobs:
           images: ghcr.io/${{ github.repository }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -136,7 +136,7 @@ jobs:
           fetch-depth: 0
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -149,10 +149,10 @@ jobs:
           images: ghcr.io/${{ github.repository }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build and push dev image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Convert repository name to lowercase
-        run: |
-          REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          echo "REPO_LC=$REPO_LC" >> $GITHUB_ENV
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -141,8 +142,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Convert repository name to lowercase
-        run: echo "REPO_LC=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -109,9 +112,8 @@ jobs:
         with:
           context: .
           push: true
-          tags: |
-            ghcr.io/${{ env.REPO_LC }}:latest
-            ghcr.io/${{ env.REPO_LC }}:${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64,linux/arm/v7
@@ -148,6 +150,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=dev
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -157,7 +161,8 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ env.REPO_LC }}:dev
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Create a dummy directory to appease the go:embed typechecker
       - name: Create dummy dist directory
-        run: mkdir -p src/web/dist && touch src/web/dist/.keep
+        run: mkdir -p src/web/dist && touch src/web/dist/index.html
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - dev
   pull_request:
     branches: ['*']
+  workflow_dispatch:
 
 name: Latest Release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.24'
+
+      # Create a dummy directory to appease the go:embed typechecker
+      - name: Create dummy dist directory
+        run: mkdir -p src/web/dist && touch src/web/dist/.keep
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
             ghcr.io/${{ env.REPO_LC }}:${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           build-args: |
             TARGETARCH
 
@@ -155,6 +155,6 @@ jobs:
           tags: ghcr.io/${{ env.REPO_LC }}:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           build-args: |
             TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:20-alpine AS ui-builder
+FROM --platform=$BUILDPLATFORM node:20-alpine AS ui-builder
 WORKDIR /app/src/web/frontend
 COPY src/web/frontend/package*.json ./
 RUN npm ci
 COPY src/web/frontend/ ./
 RUN npm run build
 
-FROM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
After the introduction of the webUI, none of the GitHub actions worked correctly. Here are the respective errors:

- `build`/`build-dev`: Node has long dropped support for `linux/386` systems, so the `node:20-alpine` image is incompatible. Additionally, the QEMU emulator GitHub uses to build `arm` images kept crashing.
- `lint`: Tries to check embedded files that don't exist yet.

Here are the fixes, plus some additional tweaks I made:

`.github/workflows/release.yaml`:

- Remove `linux/386` platform target.
- Create a dummy `dist/` directory before the `lint` step runs.
- Remove repo lowercase step and replace it with Docker's official `metadata-action`.
- Bump some action versions

`Dockerfile`

- Add `--platform=$BUILDPLATFORM` to build stages to allow Node and Go to use their native architecture while building. This removes the dependency on QEMU and speeds up builds