### PR TITLE
CLI: add -v/--version flag to print the version number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           echo "GOARCH=$GOARCH" >> $GITHUB_ENV
       - name: Build binary
         run: |
-          go build -o "$BINARY_NAME" -v ./src/main/
+          go build -ldflags "-X explo/src/config.Version=${{ github.ref_name }}" -o "$BINARY_NAME" -v ./src/main/
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
@@ -124,6 +124,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           build-args: |
             TARGETARCH
+            VERSION=${{ github.ref_name }}
 
   build-dev:
     name: Build/publish dev image

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY --from=ui-builder /app/src/web/dist ./src/web/dist
 
 # Build the Go binary based on the target architecture
 ARG TARGETARCH
-RUN GOOS=linux GOARCH=$TARGETARCH go build -o explo ./src/main/
+ARG VERSION=dev
+RUN GOOS=linux GOARCH=$TARGETARCH go build -ldflags "-X explo/src/config.Version=${VERSION}" -o explo ./src/main/
 
 FROM python:3.12-alpine
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -14,6 +14,8 @@ import (
 	"golang.org/x/text/language"
 )
 
+var Version = "dev"
+
 type Config struct {
 	DownloadCfg  DownloadConfig
 	DiscoveryCfg DiscoveryConfig

--- a/src/config/flags.go
+++ b/src/config/flags.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+
 	flag "github.com/spf13/pflag"
 	"slices"
 	"strings"
@@ -18,14 +20,21 @@ func (cfg *Config) GetFlags() error {
 	var downloadMode string
 	var excludeLocal bool
 	var persist bool
+	var showVersion bool
 	// Long flags
 	flag.StringVarP(&configPath, "config", "c", ".env", "Path of the configuration file")
 	flag.StringVarP(&playlist, "playlist", "p", "weekly-exploration", "Playlist where to get tracks. Supported: weekly-exploration, weekly-jams, daily-jams, on-repeat")
 	flag.StringVarP(&downloadMode, "download-mode", "d", "normal", "Download mode: 'normal' (download only when track is not found locally), 'skip' (skip downloading, only use tracks already found locally), 'force' (always download, don't check for local tracks)")
 	flag.BoolVarP(&excludeLocal, "exclude-local", "e", false, "Exclude locally found tracks from the imported playlist")
 	flag.BoolVar(&persist, "persist", true, "Keep playlists between generations")
+	flag.BoolVarP(&showVersion, "version", "v", false, "Print version and exit")
 
 	flag.Parse()
+
+	if showVersion {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
 	persistSet := flag.Lookup("persist").Changed
 
 	// Validation for playlist


### PR DESCRIPTION
Add a -v/--version flag that prints the binary version and exits. 
The version defaults to "dev" and is injected at build time via ldflags (-X explo/src/config.Version). 
The Dockerfile and release workflow both pass the version through during builds.

This should resolve #39 partially.