### PR TITLE
Use `dev` docker in `dev` branch

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   explo:
-    image: ghcr.io/lumepart/explo:latest
+    image: ghcr.io/lumepart/explo:dev
     restart: unless-stopped
     container_name: explo
     ports:


### PR DESCRIPTION
fixes #129 
As per issue above, I would suggest to use `dev` image in `dev` branch in the docker-compose template to enable WebUI  and avoid confusion