### PR TITLE
add keyword exclusions and file extension options for slskd in wizard

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -100,7 +100,7 @@ type DownloadConfig struct {
 }
 
 type Filters struct {
-	Extensions  []string `env:"EXTENSIONS" env-default:"flac,mp3"`
+	Extensions  []string `env:"EXTENSIONS" env-default:"flac,mp3"` // slskd
 	MinBitDepth int      `env:"MIN_BIT_DEPTH" env-default:"8"`
 	MinBitRate  int      `env:"MIN_BITRATE" env-default:"256"`
 	FilterList  []string `env:"FILTER_LIST" env-default:"live,remix,instrumental,extended,clean,acapella"`
@@ -110,7 +110,7 @@ type Youtube struct {
 	APIKey        string `env:"YOUTUBE_API_KEY"`
 	FfmpegPath    string `env:"FFMPEG_PATH"`
 	YtdlpPath     string `env:"YTDLP_PATH"`
-	FileExtension string `env:"TRACK_EXTENSION" env-default:"opus"`
+	FileExtension string `env:"TRACK_EXTENSION" env-default:"opus"` // yt-dlp
 	CookiesPath   string `env:"COOKIES_PATH" env-default:"./cookies.txt"`
 	Filters       Filters
 }

--- a/src/web/backend/server.go
+++ b/src/web/backend/server.go
@@ -584,10 +584,11 @@ func (s *Server) handleWizardStep3(w http.ResponseWriter, r *http.Request) {
 		MigrateDownloads bool     `json:"migrate_downloads"`
 		DownloadServices []string `json:"download_services"`
 		YoutubeAPIKey    string   `json:"youtube_api_key"`
-		TrackExtension   string   `json:"track_extension"`
+		TrackExtension   string   `json:"track_extension"` // yt-dlp
 		FilterList       string   `json:"filter_list"`
 		SlskdURL         string   `json:"slskd_url"`
 		SlskdAPIKey      string   `json:"slskd_api_key"`
+		Extensions       string   `json:"extensions"`      // slskd
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
@@ -613,10 +614,11 @@ func (s *Server) handleWizardStep3(w http.ResponseWriter, r *http.Request) {
 		"MIGRATE_DOWNLOADS": migrateDL,
 		"DOWNLOAD_SERVICES": joined,
 		"YOUTUBE_API_KEY":   body.YoutubeAPIKey,
-		"TRACK_EXTENSION":   body.TrackExtension,
+		"TRACK_EXTENSION":   body.TrackExtension, // yt-dlp
 		"FILTER_LIST":       body.FilterList,
 		"SLSKD_URL":         body.SlskdURL,
 		"SLSKD_API_KEY":     body.SlskdAPIKey,
+		"EXTENSIONS":        body.Extensions,        // slskd
 		"WIZARD_COMPLETE":	 "true",
 	}
 

--- a/src/web/frontend/src/components/Wizard.jsx
+++ b/src/web/frontend/src/components/Wizard.jsx
@@ -256,7 +256,7 @@ function Collapse({ open, children }) {
 
 function Step3({ fields, setField, envSources, onBack, onFinish, saving }) {
   const { downloadDir, useSubdirectory, migrateDownloads, dlServices,
-          youtubeApiKey, trackExtension, filterList, slskdUrl, slskdApiKey } = fields
+          youtubeApiKey, trackExtension, filterList, slskdUrl, slskdApiKey, extensions } = fields
   const isLocked = key => envSources[key] === 'env'
 
   const valid = () => {
@@ -333,6 +333,16 @@ function Step3({ fields, setField, envSources, onBack, onFinish, saving }) {
               <TextField label="Slskd API Key">
                 <input type="text" className={inputCls} value={slskdApiKey} onChange={e => setField('slskdApiKey', e.target.value)}
                   autoComplete="off" spellCheck={false} disabled={isLocked('SLSKD_API_KEY')} />
+              </TextField>
+              <TextField label="File extensions"
+                hint="Comma-separated list of extensions to prefer, in priority order. No spaces.">
+                <input type="text" className={inputCls} value={extensions} onChange={e => setField('extensions', e.target.value)}
+                  placeholder="flac,mp3" autoComplete="off" spellCheck={false} disabled={isLocked('EXTENSIONS')} />
+              </TextField>
+              <TextField label="Exclude keywords"
+                hint="Leave blank to use the defaults shown.">
+                <input type="text" className={inputCls} value={filterList} onChange={e => setField('filterList', e.target.value)}
+                  placeholder="live,remix,instrumental,extended,clean,acapella" autoComplete="off" spellCheck={false} disabled={isLocked('FILTER_LIST')} />
               </TextField>
               <div className="flex flex-col gap-1.5">
                 <p className="text-[12px] text-muted leading-relaxed">
@@ -414,6 +424,7 @@ export default function Wizard({ config, envSources, bgUrl, bgLoaded, onBgLoad, 
       filterList:       config.FILTER_LIST || '',
       slskdUrl:         config.SLSKD_URL || '',
       slskdApiKey:      config.SLSKD_API_KEY || '',
+      extensions:       config.EXTENSIONS || '',
     }
   })
 
@@ -465,6 +476,7 @@ export default function Wizard({ config, envSources, bgUrl, bgLoaded, onBgLoad, 
         migrate_downloads: fields.migrateDownloads, download_services: services,
         youtube_api_key: fields.youtubeApiKey, track_extension: fields.trackExtension,
         filter_list: fields.filterList, slskd_url: fields.slskdUrl, slskd_api_key: fields.slskdApiKey,
+        extensions: fields.extensions,
       })
       onComplete()
     } catch (e) {


### PR DESCRIPTION
Noticed the slskd options lacked the keyword exclusions and file extension options like yt-dlp had. quickly added them to the wizard. 