### PR TITLE
Add Hotfix for .env first time startup issues

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -174,12 +174,23 @@ type HttpNotif struct {
 }
 
 func (cfg *Config) ReadEnv() {
+	// fallback in case the user adds path/.env as a directory
+	if info, err := os.Stat(cfg.Flags.CfgPath); err == nil && info.IsDir() {
+		cfg.Flags.CfgPath = filepath.Join(cfg.Flags.CfgPath, ".env")
+		slog.Warn("config path is a directory, using .env inside it", "path", cfg.Flags.CfgPath)
+	}
 
 	// Try to read from .env file first
 	err := cleanenv.ReadConfig(cfg.Flags.CfgPath, cfg)
 	if err != nil {
 		// If the error is because the file doesn't exist, fallback to env vars
 		if errors.Is(err, os.ErrNotExist) {
+			slog.Warn("no config file found, creating empty one", "path", cfg.Flags.CfgPath)
+			if f, err := os.Create(cfg.Flags.CfgPath); err != nil {
+				slog.Warn("could not create config file", "path", cfg.Flags.CfgPath, "context", err.Error())
+			} else {
+				f.Close()
+			}
 			if err := cleanenv.ReadEnv(&cfg); err != nil {
 				slog.Error("failed to load config from env vars", "context", err.Error())
 				os.Exit(1)

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -188,8 +188,8 @@ func (cfg *Config) ReadEnv() {
 			slog.Warn("no config file found, creating empty one", "path", cfg.Flags.CfgPath)
 			if f, err := os.Create(cfg.Flags.CfgPath); err != nil {
 				slog.Warn("could not create config file", "path", cfg.Flags.CfgPath, "context", err.Error())
-			} else {
-				f.Close()
+			} else if err := f.Close(); err != nil {
+				slog.Warn("could not close config file", "path", cfg.Flags.CfgPath, "context", err.Error())
 			}
 			if err := cleanenv.ReadConfig(cfg.Flags.CfgPath, cfg); err != nil {
 				slog.Error("failed to load config file", "path", cfg.Flags.CfgPath, "context", err.Error())

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -191,8 +191,8 @@ func (cfg *Config) ReadEnv() {
 			} else {
 				f.Close()
 			}
-			if err := cleanenv.ReadEnv(&cfg); err != nil {
-				slog.Error("failed to load config from env vars", "context", err.Error())
+			if err := cleanenv.ReadConfig(cfg.Flags.CfgPath, cfg); err != nil {
+				slog.Error("failed to load config file", "path", cfg.Flags.CfgPath, "context", err.Error())
 				os.Exit(1)
 			}
 		} else {


### PR DESCRIPTION
Some quick last min fixes to some common first-time startup issues:

• If the config path is mounted as a directory (a common mistake), explo will automatically redirect to .env inside it.
• If no config file is found, creates an empty one so the web UI has a file to write to on first, instead of crashing on env var fallback.