### PR TITLE
feat: aditional metadata

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -51,6 +51,8 @@ LIBRARY_NAME=
 YOUTUBE_API_KEY=
 # Custom file extension for tracks (e.g mp3) (default: opus)
 # TRACK_EXTENSION=opus
+# Include cover art in downloaded files (default: false)
+# EMBED_COVER_ART=false
 # Custom path to ffmpeg binary (default: defined in $PATH)
 # FFMPEG_PATH=
 # Custom path to yt-dlp binary (default: defined in $PATH)

--- a/sample.env
+++ b/sample.env
@@ -6,6 +6,8 @@
 LISTENBRAINZ_USER=
 # 'playlist' to fetch weekly playlist (50 songs), 'api' for fewer songs (good for testing) (default: playlist)
 # LISTENBRAINZ_DISCOVERY=playlist
+# Size of the cover art downloaded from coverartarchive (250 or 500) (default: 250)
+# COVERART_SIZE=250
 
 # === Music System Configuration ===
 

--- a/sample.env
+++ b/sample.env
@@ -8,6 +8,8 @@ LISTENBRAINZ_USER=
 # LISTENBRAINZ_DISCOVERY=playlist
 # Size of the cover art downloaded from coverartarchive (250 or 500) (default: 250)
 # COVERART_SIZE=250
+# Enrich playlist tracks with full metadata from metadata/recording endpoint (default: false)
+# ENRICH_PLAYLIST_METADATA=false
 
 # === Music System Configuration ===
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	DiscoveryCfg DiscoveryConfig
 	ClientCfg    ClientConfig
 	NotifyCfg    NotifyConfig
-	ServerCfg	 ServerConfig
+	ServerCfg    ServerConfig
 	Flags        Flags
 	PersistENV   bool `env:"PERSIST" env-default:"true"`
 	Persist      bool
@@ -32,7 +32,7 @@ type Config struct {
 
 type Flags struct {
 	CfgPath      string
-	CfgSet		 bool
+	CfgSet       bool
 	Playlist     string
 	DownloadMode string
 	ExcludeLocal bool
@@ -41,14 +41,14 @@ type Flags struct {
 }
 
 type ServerConfig struct {
-	Enabled bool `env:"WEB_UI" env-default:"false"`
-	Port string `env:"WEB_ADDR" env-default:":7288"`
-	Username string `env:"UI_USERNAME"`
-	Password string `env:"UI_PASSWORD"`
-	WebDataDir string `env:"WEB_DATA_PATH" env-default:"/opt/explo/config/"`
-	WebEnvPath string `env:"WEB_ENV_PATH" env-default:"/opt/explo/.env"`
+	Enabled     bool   `env:"WEB_UI" env-default:"false"`
+	Port        string `env:"WEB_ADDR" env-default:":7288"`
+	Username    string `env:"UI_USERNAME"`
+	Password    string `env:"UI_PASSWORD"`
+	WebDataDir  string `env:"WEB_DATA_PATH" env-default:"/opt/explo/config/"`
+	WebEnvPath  string `env:"WEB_ENV_PATH" env-default:"/opt/explo/.env"`
 	CacheSizeMB int64  `env:"WEB_CACHE_MB" env-default:"500"`
-	ExploPath string
+	ExploPath   string
 }
 
 type ClientConfig struct {
@@ -148,7 +148,8 @@ type Listenbrainz struct {
 	Discovery      string `env:"LISTENBRAINZ_DISCOVERY" env-default:"playlist"`
 	User           string `env:"LISTENBRAINZ_USER"`
 	ImportPlaylist string
-	SingleArtist   bool `env:"SINGLE_ARTIST" env-default:"true"`
+	SingleArtist   bool   `env:"SINGLE_ARTIST" env-default:"true"`
+	CoverArtSize   string `env:"COVERART_SIZE" env-default:"250"`
 }
 
 type NotifyConfig struct {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -116,6 +116,7 @@ type Youtube struct {
 	EmbedCoverArt bool   `env:"EMBED_COVER_ART" env-default:"false"`
 	CookiesPath   string `env:"COOKIES_PATH" env-default:"./cookies.txt"`
 	Filters       Filters
+	CoversDir     string
 }
 
 type YoutubeMusic struct {
@@ -208,6 +209,7 @@ func (cfg *Config) ReadEnv() {
 
 func (cfg *Config) CommonFixes() {
 	cfg.DownloadCfg.Youtube.FileExtension = strings.TrimPrefix(cfg.DownloadCfg.Youtube.FileExtension, ".")
+	cfg.DownloadCfg.Youtube.CoversDir = filepath.Join(filepath.Dir(cfg.Flags.CfgPath), "cache", "covers")
 	cfg.ClientCfg.URL = fixBaseURL(cfg.ClientCfg.URL)
 	cfg.DownloadCfg.Slskd.URL = fixBaseURL(cfg.DownloadCfg.Slskd.URL)
 	cfg.NormalizeDir()

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -147,11 +147,12 @@ type DiscoveryConfig struct {
 	Listenbrainz Listenbrainz
 }
 type Listenbrainz struct {
-	Discovery      string `env:"LISTENBRAINZ_DISCOVERY" env-default:"playlist"`
-	User           string `env:"LISTENBRAINZ_USER"`
-	ImportPlaylist string
-	SingleArtist   bool   `env:"SINGLE_ARTIST" env-default:"true"`
-	CoverArtSize   string `env:"COVERART_SIZE" env-default:"250"`
+	Discovery              string `env:"LISTENBRAINZ_DISCOVERY" env-default:"playlist"`
+	User                   string `env:"LISTENBRAINZ_USER"`
+	ImportPlaylist         string
+	SingleArtist           bool   `env:"SINGLE_ARTIST" env-default:"true"`
+	CoverArtSize           string `env:"COVERART_SIZE" env-default:"250"`
+	EnrichPlaylistMetadata bool   `env:"ENRICH_PLAYLIST_METADATA" env-default:"false"`
 }
 
 type NotifyConfig struct {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -113,6 +113,7 @@ type Youtube struct {
 	FfmpegPath    string `env:"FFMPEG_PATH"`
 	YtdlpPath     string `env:"YTDLP_PATH"`
 	FileExtension string `env:"TRACK_EXTENSION" env-default:"opus"` // yt-dlp
+	EmbedCoverArt bool   `env:"EMBED_COVER_ART" env-default:"false"`
 	CookiesPath   string `env:"COOKIES_PATH" env-default:"./cookies.txt"`
 	Filters       Filters
 }

--- a/src/discovery/listenbrainz.go
+++ b/src/discovery/listenbrainz.go
@@ -438,7 +438,21 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 		discTotal := 0
 		mbReleaseTrackID := ""
 
-		if mbData, err := c.mbRequest(fmt.Sprintf("recording/%s?inc=media+releases+artist-credits+release-groups&fmt=json", track.MusicBrainzTrackID)); err == nil && mbData != nil {
+		var mbData *MBRecording
+		var mbErr error
+		for attempt := 1; attempt <= 3; attempt++ {
+			mbData, mbErr = c.mbRequest(fmt.Sprintf("recording/%s?inc=media+releases+artist-credits+release-groups&fmt=json", track.MusicBrainzTrackID))
+			if mbErr == nil && mbData != nil {
+				break
+			}
+
+			if attempt < 3 {
+				slog.Warn("retrying MusicBrainz enrichment request", "track", track.Title, "mbid", track.MusicBrainzTrackID, "attempt", attempt, "error", mbErr)
+				time.Sleep(1500 * time.Millisecond)
+			}
+		}
+
+		if mbData != nil {
 			if len(mbData.Releases) > 0 {
 				// Find best matching release
 				bestRelease := mbData.Releases[0]
@@ -479,8 +493,8 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 					}
 				}
 			}
-		} else if err != nil {
-			slog.Debug("failed to enrich from MusicBrainz", "mbid", track.MusicBrainzTrackID, "error", err)
+		} else {
+			slog.Debug("failed to enrich from MusicBrainz after retries", "mbid", track.MusicBrainzTrackID, "error", mbErr)
 		}
 
 		tracks[i] = &models.Track{

--- a/src/discovery/listenbrainz.go
+++ b/src/discovery/listenbrainz.go
@@ -147,6 +147,39 @@ type TopRecordings struct {
 	} `json:"payload"`
 }
 
+type MBRecording struct {
+	ID       string `json:"id"`
+	Releases []struct {
+		ID           string `json:"id"`
+		Title        string `json:"title"`
+		Status       string `json:"status"`
+		Country      string `json:"country"`
+		Date         string `json:"date"`
+		Year         int    `json:"year,omitempty"`
+		ArtistCredit []struct {
+			Name   string `json:"name"`
+			Artist struct {
+				ID       string `json:"id"`
+				SortName string `json:"sort-name"`
+			} `json:"artist"`
+		} `json:"artist-credit"`
+		ReleaseGroup struct {
+			ID          string `json:"id"`
+			PrimaryType string `json:"primary-type"`
+		} `json:"release-group"`
+		Media []struct {
+			Position   int    `json:"position"`
+			Format     string `json:"format"`
+			TrackCount int    `json:"track-count"`
+			Tracks     []struct {
+				ID       string `json:"id"`
+				Position int    `json:"position"`
+				Number   string `json:"number"`
+			} `json:"tracks"`
+		} `json:"media"`
+	} `json:"releases"`
+}
+
 type ListenBrainz struct {
 	HttpClient *util.HttpClient
 	cfg        cfg.Listenbrainz
@@ -393,6 +426,63 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 			}
 		}
 
+		releaseCountry := ""
+		releaseStatus := recording.Release.Status
+		mbReleaseGroupID := recording.Release.ReleaseGroupMbid
+		mbAlbumArtistID := ""
+		artistSort := ""
+		media := ""
+		trackNumber := 0
+		trackTotal := 0
+		discNumber := 0
+		discTotal := 0
+		mbReleaseTrackID := ""
+
+		if mbData, err := c.mbRequest(fmt.Sprintf("recording/%s?inc=media+releases+artist-credits+release-groups&fmt=json", track.MusicBrainzTrackID)); err == nil && mbData != nil {
+			if len(mbData.Releases) > 0 {
+				// Find best matching release
+				bestRelease := mbData.Releases[0]
+				if track.MusicBrainzAlbumID != "" {
+					for _, rel := range mbData.Releases {
+						if rel.ID == track.MusicBrainzAlbumID {
+							bestRelease = rel
+							break
+						}
+					}
+				}
+
+				if bestRelease.Country != "" {
+					releaseCountry = bestRelease.Country
+				}
+				if bestRelease.Status != "" {
+					releaseStatus = bestRelease.Status
+				}
+				if bestRelease.ReleaseGroup.ID != "" {
+					mbReleaseGroupID = bestRelease.ReleaseGroup.ID
+				}
+				if len(bestRelease.ArtistCredit) > 0 {
+					mbAlbumArtistID = bestRelease.ArtistCredit[0].Artist.ID
+					artistSort = bestRelease.ArtistCredit[0].Artist.SortName
+				}
+
+				discTotal = len(bestRelease.Media)
+				if len(bestRelease.Media) > 0 {
+					firstMedia := bestRelease.Media[0]
+					media = firstMedia.Format
+					discNumber = firstMedia.Position
+					trackTotal = firstMedia.TrackCount
+
+					if len(firstMedia.Tracks) > 0 {
+						firstTrack := firstMedia.Tracks[0]
+						trackNumber = firstTrack.Position
+						mbReleaseTrackID = firstTrack.ID
+					}
+				}
+			}
+		} else if err != nil {
+			slog.Debug("failed to enrich from MusicBrainz", "mbid", track.MusicBrainzTrackID, "error", err)
+		}
+
 		tracks[i] = &models.Track{
 			ID:                        track.ID,
 			File:                      track.File,
@@ -403,19 +493,28 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 			Artist:                    artist,
 			MainArtist:                mainArtist,
 			MainArtistID:              mainArtistID,
+			ArtistSort:                artistSort,
 			CleanTitle:                rec.Name,
 			Title:                     title,
 			Duration:                  rec.Length,
-			ReleaseStatus:             recording.Release.Status,
+			ReleaseCountry:            releaseCountry,
+			ReleaseStatus:             releaseStatus,
 			ReleaseType:               recording.Release.ReleaseGroup.PrimaryType,
 			OriginalDate:              originalDate,
 			OriginalYear:              originalYear,
 			CoverURL:                  track.CoverURL,
 			Genres:                    strings.Join(genres, "; "),
 			ISRCs:                     append([]string(nil), rec.ISRCs...),
+			Media:                     media,
+			TrackNumber:               trackNumber,
+			TrackTotal:                trackTotal,
+			DiscNumber:                discNumber,
+			DiscTotal:                 discTotal,
 			MusicBrainzTrackID:        track.MusicBrainzTrackID,
 			MusicBrainzAlbumID:        recording.Release.CaaReleaseMbid,
-			MusicBrainzReleaseGroupID: recording.Release.ReleaseGroupMbid,
+			MusicBrainzReleaseGroupID: mbReleaseGroupID,
+			MusicBrainzAlbumArtistID:  mbAlbumArtistID,
+			MusicBrainzReleaseTrackID: mbReleaseTrackID,
 			MusicBrainzArtistID: func() string {
 				if len(recArtists) == 0 {
 					return ""
@@ -575,6 +674,27 @@ func (c *ListenBrainz) lbRequest(path string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+func (c *ListenBrainz) mbRequest(path string) (*MBRecording, error) {
+	reqURL := fmt.Sprintf("https://musicbrainz.org/ws/2/%s", path)
+	body, err := c.HttpClient.MakeRequest("GET", reqURL, nil, map[string]string{
+		"User-Agent": "Explo/1.0",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request to MusicBrainz API: %s", err)
+	}
+
+	if len(body) == 0 {
+		return nil, fmt.Errorf("MusicBrainz API returned empty response for: %s", reqURL)
+	}
+
+	var recording MBRecording
+	if err := util.ParseResp(body, &recording); err != nil {
+		return nil, fmt.Errorf("failed to parse MusicBrainz response: %s", err)
+	}
+
+	return &recording, nil
 }
 
 type LBTag struct {

--- a/src/discovery/listenbrainz.go
+++ b/src/discovery/listenbrainz.go
@@ -393,6 +393,8 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 		}
 
 		recArtists := recording.Artist.Artists
+		artists := make([]string, 0, len(recArtists))
+
 		genres := topTags(recording.Tag.Recording, 3)
 		if len(genres) == 0 {
 			genres = topTags(recording.Tag.ReleaseGroup, 3)
@@ -423,6 +425,10 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 
 				title = b.String()
 				artist = mainArtist
+			} else {
+				for _, recArtist := range recArtists {
+					artists = append(artists, recArtist.Name)
+				}
 			}
 		}
 
@@ -447,7 +453,6 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 			}
 
 			if attempt < 3 {
-				slog.Warn("retrying MusicBrainz enrichment request", "track", track.Title, "mbid", track.MusicBrainzTrackID, "attempt", attempt, "error", mbErr)
 				time.Sleep(1500 * time.Millisecond)
 			}
 		}
@@ -505,6 +510,7 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 			Album:                     recording.Release.Name,
 			AlbumArtist:               recording.Release.AlbumArtistName,
 			Artist:                    artist,
+			Artists:                   artists,
 			MainArtist:                mainArtist,
 			MainArtistID:              mainArtistID,
 			ArtistSort:                artistSort,

--- a/src/discovery/listenbrainz.go
+++ b/src/discovery/listenbrainz.go
@@ -443,6 +443,7 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 		discNumber := 0
 		discTotal := 0
 		mbReleaseTrackID := ""
+		releaseType := ""
 
 		var mbData *MBRecording
 		var mbErr error
@@ -478,6 +479,9 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 				}
 				if bestRelease.ReleaseGroup.ID != "" {
 					mbReleaseGroupID = bestRelease.ReleaseGroup.ID
+				}
+				if bestRelease.ReleaseGroup.PrimaryType != "" {
+					releaseType = bestRelease.ReleaseGroup.PrimaryType
 				}
 				if len(bestRelease.ArtistCredit) > 0 {
 					mbAlbumArtistID = bestRelease.ArtistCredit[0].Artist.ID
@@ -519,7 +523,7 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 			Duration:                  rec.Length,
 			ReleaseCountry:            releaseCountry,
 			ReleaseStatus:             releaseStatus,
-			ReleaseType:               recording.Release.ReleaseGroup.PrimaryType,
+			ReleaseType:               releaseType,
 			OriginalDate:              originalDate,
 			OriginalYear:              originalYear,
 			CoverURL:                  track.CoverURL,

--- a/src/discovery/listenbrainz.go
+++ b/src/discovery/listenbrainz.go
@@ -3,6 +3,8 @@ package discovery
 import (
 	"fmt"
 	"log/slog"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +29,11 @@ type Recommendations struct {
 }
 
 type Metadata struct {
+	Tag struct {
+		Artist       []LBTag `json:"artist"`
+		Recording    []LBTag `json:"recording"`
+		ReleaseGroup []LBTag `json:"release_group"`
+	} `json:"tag"`
 	Artist struct {
 		ArtistCreditID int `json:"artist_credit_id"`
 		Artists        []struct {
@@ -39,19 +46,36 @@ type Metadata struct {
 		Name string `json:"name"`
 	} `json:"artist"`
 	Recording struct {
-		Length int    `json:"length"`
-		Name   string `json:"name"`
-		Rels   []any  `json:"rels"`
+		FirstReleaseDate string   `json:"first_release_date"`
+		ISRCs            []string `json:"isrcs"`
+		Length           int      `json:"length"`
+		Name             string   `json:"name"`
+		Rels             []any    `json:"rels"`
+		URLRels          []struct {
+			Type string `json:"type"`
+			URL  string `json:"url"`
+		} `json:"url_rels"`
 	} `json:"recording"`
-	Release struct {
-		AlbumArtistName  string `json:"album_artist_name"`
-		CaaID            int64  `json:"caa_id"`
-		CaaReleaseMbid   string `json:"caa_release_mbid"`
-		Mbid             string `json:"mbid"`
-		Name             string `json:"name"`
-		ReleaseGroupMbid string `json:"release_group_mbid"`
-		Year             int    `json:"year"`
-	} `json:"release"`
+	Release ReleaseMetadata `json:"release"`
+}
+
+type ReleaseMetadata struct {
+	AlbumArtistName string `json:"album_artist_name"`
+	CaaID           int64  `json:"caa_id"`
+	CaaReleaseMbid  string `json:"caa_release_mbid"`
+	ReleaseGroup    struct {
+		ID               string   `json:"id"`
+		PrimaryType      string   `json:"primary_type"`
+		SecondaryTypes   []string `json:"secondary_types"`
+		FirstReleaseDate string   `json:"first_release_date"`
+		Title            string   `json:"title"`
+	} `json:"release_group"`
+	Status           string `json:"status"`
+	Mbid             string `json:"mbid"`
+	MBReleaseID      string `json:"mb_release_id"`
+	Name             string `json:"name"`
+	ReleaseGroupMbid string `json:"release_group_mbid"`
+	Year             int    `json:"year"`
 }
 
 type Recordings map[string]Metadata
@@ -152,6 +176,14 @@ func (c *ListenBrainz) QueryTracks() ([]*models.Track, error) {
 		tracks, err = c.parsePlaylist(id, c.cfg.SingleArtist)
 		if err != nil {
 			return nil, err
+		}
+		if c.cfg.EnrichPlaylistMetadata && len(tracks) > 0 {
+			enrichedTracks, err := c.enrichTracks(tracks, c.cfg.SingleArtist)
+			if err != nil {
+				slog.Warn("failed to enrich playlist metadata", "error", err)
+			} else {
+				tracks = enrichedTracks
+			}
 		}
 
 	default:
@@ -278,10 +310,119 @@ func (c *ListenBrainz) getTracks(mbids []string, singleArtist bool) ([]*models.T
 			Title:                     title,
 			Duration:                  rec.Length,
 			MusicBrainzTrackID:        mbTrackID,
-			MusicBrainzAlbumID:        recording.Release.Mbid,
+			MusicBrainzAlbumID:        recording.Release.CaaReleaseMbid,
 			MusicBrainzReleaseGroupID: recording.Release.ReleaseGroupMbid,
 			MusicBrainzArtistID:       recArtists[0].ArtistMbid,
 		})
+	}
+
+	return tracks, nil
+
+}
+
+func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) ([]*models.Track, error) {
+	mbids := make([]string, 0, len(tracks))
+	for _, track := range tracks {
+		if track.MusicBrainzTrackID != "" {
+			mbids = append(mbids, track.MusicBrainzTrackID)
+		}
+	}
+	strMbids := strings.Join(mbids, ",")
+
+	body, err := c.lbRequest(fmt.Sprintf("metadata/recording/?recording_mbids=%s&inc=release+artist+tag+release_group+recording", strMbids))
+	if err != nil {
+		return nil, fmt.Errorf("getTracks(): %s", err.Error())
+	}
+
+	var recordings Recordings
+	if err := util.ParseResp(body, &recordings); err != nil {
+		return nil, fmt.Errorf("getTracks(): %s", err.Error())
+	}
+
+	if len(recordings) == 0 {
+		return nil, fmt.Errorf("no recordings found for MBIDs: %s", strMbids)
+	}
+
+	for i, track := range tracks {
+		recording, ok := recordings[track.MusicBrainzTrackID]
+		if !ok {
+			continue
+		}
+
+		rec := recording.Recording
+
+		title := rec.Name
+		artist := recording.Artist.Name
+		mainArtist := recording.Artist.Name
+		mainArtistID := ""
+		if len(recording.Artist.Artists) > 0 {
+			mainArtistID = recording.Artist.Artists[0].ArtistMbid
+		}
+
+		recArtists := recording.Artist.Artists
+		genres := topTags(recording.Tag.Recording, 3)
+		if len(genres) == 0 {
+			genres = topTags(recording.Tag.ReleaseGroup, 3)
+		}
+		if len(genres) == 0 {
+			genres = topTags(recording.Tag.Artist, 3)
+		}
+		originalDate := rec.FirstReleaseDate
+		originalYear := recording.Release.Year
+		if originalYear == 0 && originalDate != "" && len(originalDate) >= 4 {
+			if year, err := strconv.Atoi(originalDate[:4]); err == nil {
+				originalYear = year
+			}
+		}
+
+		if len(recArtists) > 1 {
+			mainArtist = recArtists[0].Name
+			if singleArtist {
+				var b strings.Builder
+				b.WriteString(title)
+				b.WriteString(" feat. ")
+				b.WriteString(recArtists[1].Name)
+
+				for _, a := range recArtists[2:] {
+					b.WriteString(", ")
+					b.WriteString(a.Name)
+				}
+
+				title = b.String()
+				artist = mainArtist
+			}
+		}
+
+		tracks[i] = &models.Track{
+			ID:                        track.ID,
+			File:                      track.File,
+			Size:                      track.Size,
+			Present:                   track.Present,
+			Album:                     recording.Release.Name,
+			AlbumArtist:               recording.Release.AlbumArtistName,
+			Artist:                    artist,
+			MainArtist:                mainArtist,
+			MainArtistID:              mainArtistID,
+			CleanTitle:                rec.Name,
+			Title:                     title,
+			Duration:                  rec.Length,
+			ReleaseStatus:             recording.Release.Status,
+			ReleaseType:               recording.Release.ReleaseGroup.PrimaryType,
+			OriginalDate:              originalDate,
+			OriginalYear:              originalYear,
+			CoverURL:                  track.CoverURL,
+			Genres:                    strings.Join(genres, "; "),
+			ISRCs:                     append([]string(nil), rec.ISRCs...),
+			MusicBrainzTrackID:        track.MusicBrainzTrackID,
+			MusicBrainzAlbumID:        recording.Release.CaaReleaseMbid,
+			MusicBrainzReleaseGroupID: recording.Release.ReleaseGroupMbid,
+			MusicBrainzArtistID: func() string {
+				if len(recArtists) == 0 {
+					return ""
+				}
+				return recArtists[0].ArtistMbid
+			}(),
+		}
 	}
 
 	return tracks, nil
@@ -434,4 +575,35 @@ func (c *ListenBrainz) lbRequest(path string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+type LBTag struct {
+	Count int    `json:"count"`
+	Tag   string `json:"tag"`
+}
+
+func topTags(tags []LBTag, limit int) []string {
+	if len(tags) == 0 || limit <= 0 {
+		return nil
+	}
+
+	ordered := append([]LBTag(nil), tags...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].Count == ordered[j].Count {
+			return ordered[i].Tag < ordered[j].Tag
+		}
+		return ordered[i].Count > ordered[j].Count
+	})
+
+	if limit > len(ordered) {
+		limit = len(ordered)
+	}
+
+	out := make([]string, 0, limit)
+	for _, tag := range ordered[:limit] {
+		if tag.Tag != "" {
+			out = append(out, tag.Tag)
+		}
+	}
+	return out
 }

--- a/src/discovery/listenbrainz.go
+++ b/src/discovery/listenbrainz.go
@@ -210,7 +210,7 @@ func (c *ListenBrainz) getTopRecordings(user string) ([]*models.Track, error) {
 	for _, rec := range resp.Payload.Recordings {
 		var coverURL string
 		if rec.ReleaseMbid != "" {
-			coverURL = fmt.Sprintf("https://coverartarchive.org/release/%s/front-250", rec.ReleaseMbid)
+			coverURL = fmt.Sprintf("https://coverartarchive.org/release/%s/front-%s", rec.ReleaseMbid, c.cfg.CoverArtSize)
 		}
 		tracks = append(tracks, &models.Track{
 			Title:      rec.TrackName,
@@ -370,8 +370,8 @@ func (c *ListenBrainz) parsePlaylist(identifier string, singleArtist bool) ([]*m
 
 		var coverURL string
 		if trackMeta.CaaReleaseMbid != "" && trackMeta.CaaID != 0 {
-			coverURL = fmt.Sprintf("https://coverartarchive.org/release/%s/%d-250.jpg",
-				trackMeta.CaaReleaseMbid, trackMeta.CaaID)
+			coverURL = fmt.Sprintf("https://coverartarchive.org/release/%s/%d-%s.jpg",
+				trackMeta.CaaReleaseMbid, trackMeta.CaaID, c.cfg.CoverArtSize)
 		}
 
 		if len(trackMeta.Artists) > 1 {

--- a/src/discovery/listenbrainz.go
+++ b/src/discovery/listenbrainz.go
@@ -402,7 +402,7 @@ func (c *ListenBrainz) enrichTracks(tracks []*models.Track, singleArtist bool) (
 		}
 		originalDate := rec.FirstReleaseDate
 		originalYear := recording.Release.Year
-		if originalYear == 0 && originalDate != "" && len(originalDate) >= 4 {
+		if originalYear == 0 && len(originalDate) >= 4 {
 			if year, err := strconv.Atoi(originalDate[:4]); err == nil {
 				originalYear = year
 			}

--- a/src/discovery/listenbrainz.go
+++ b/src/discovery/listenbrainz.go
@@ -243,7 +243,7 @@ func (c *ListenBrainz) getTracks(mbids []string, singleArtist bool) ([]*models.T
 	}
 
 	tracks := make([]*models.Track, 0, len(recordings))
-	for _, recording := range recordings {
+	for mbTrackID, recording := range recordings {
 		rec := recording.Recording
 
 		title := rec.Name
@@ -271,12 +271,16 @@ func (c *ListenBrainz) getTracks(mbids []string, singleArtist bool) ([]*models.T
 		}
 
 		tracks = append(tracks, &models.Track{
-			Album:      recording.Release.Name,
-			Artist:     artist,
-			MainArtist: mainArtist,
-			CleanTitle: rec.Name,
-			Title:      title,
-			Duration:   rec.Length,
+			Album:                     recording.Release.Name,
+			Artist:                    artist,
+			MainArtist:                mainArtist,
+			CleanTitle:                rec.Name,
+			Title:                     title,
+			Duration:                  rec.Length,
+			MusicBrainzTrackID:        mbTrackID,
+			MusicBrainzAlbumID:        recording.Release.Mbid,
+			MusicBrainzReleaseGroupID: recording.Release.ReleaseGroupMbid,
+			MusicBrainzArtistID:       recArtists[0].ArtistMbid,
 		})
 	}
 
@@ -340,7 +344,6 @@ func (c *ListenBrainz) getImportPlaylist(user string) (string, error) {
 	return bestID, nil
 }
 
-
 func (c *ListenBrainz) parsePlaylist(identifier string, singleArtist bool) ([]*models.Track, error) {
 	body, err := c.lbRequest(fmt.Sprintf("playlist/%s", identifier))
 	if err != nil {
@@ -388,14 +391,28 @@ func (c *ListenBrainz) parsePlaylist(identifier string, singleArtist bool) ([]*m
 			}
 		}
 
+		recordingMBID := ""
+		if len(track.Identifier) > 0 {
+			parts := strings.Split(track.Identifier[0], "/")
+			recordingMBID = parts[len(parts)-1]
+		}
+
+		artistMBID := ""
+		if len(trackMeta.Artists) > 0 {
+			artistMBID = trackMeta.Artists[0].ArtistMbid
+		}
+
 		tracks = append(tracks, &models.Track{
-			Album:      track.Album,
-			MainArtist: mainArtist,
-			Artist:     artist,
-			CleanTitle: track.Title,
-			Title:      title,
-			Duration:   track.Duration,
-			CoverURL:   coverURL,
+			Album:               track.Album,
+			MainArtist:          mainArtist,
+			Artist:              artist,
+			CleanTitle:          track.Title,
+			Title:               title,
+			Duration:            track.Duration,
+			CoverURL:            coverURL,
+			MusicBrainzTrackID:  recordingMBID,
+			MusicBrainzArtistID: artistMBID,
+			MusicBrainzAlbumID:  trackMeta.CaaReleaseMbid,
 		})
 	}
 

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -228,8 +228,9 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 	var cmd *ffmpeg.Stream
 
 	if c.Cfg.EmbedCoverArt {
-		util.DownloadCover(track.CoverURL, c.DownloadDir)
-		coverPath := filepath.Join(c.DownloadDir, track.MusicBrainzAlbumID+".jpg")
+		coversDir := c.Cfg.CoversDir
+		util.DownloadCover(track.CoverURL, coversDir)
+		coverPath := filepath.Join(coversDir, track.MusicBrainzAlbumID+".jpg")
 		cmd = ffmpeg.Output([]*ffmpeg.Stream{ffmpeg.Input(input), ffmpeg.Input(coverPath)}, filepath.Join(c.DownloadDir, track.File), ffmpeg.KwArgs{
 			"metadata": metadata,
 			"loglevel": "error",

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -203,69 +203,7 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 		return false
 	}
 
-	metadata := []string{"ARTIST=" + track.Artist, "TITLE=" + track.Title, "ALBUM=" + track.Album}
-	if track.AlbumArtist != "" {
-		metadata = append(metadata, "ALBUMARTIST="+track.AlbumArtist)
-	}
-	if track.ArtistSort != "" {
-		metadata = append(metadata, "ARTISTSORT="+track.ArtistSort)
-	}
-	if track.OriginalDate != "" {
-		metadata = append(metadata, "ORIGINALDATE="+track.OriginalDate)
-	}
-	if track.OriginalYear != 0 {
-		metadata = append(metadata, fmt.Sprintf("ORIGINALYEAR=%d", track.OriginalYear))
-	}
-	if track.ReleaseCountry != "" {
-		metadata = append(metadata, "RELEASECOUNTRY="+track.ReleaseCountry)
-	}
-	if track.ReleaseStatus != "" {
-		metadata = append(metadata, "RELEASESTATUS="+track.ReleaseStatus)
-	}
-	if track.ReleaseType != "" {
-		metadata = append(metadata, "RELEASETYPE="+track.ReleaseType)
-	}
-	if track.Genres != "" {
-		metadata = append(metadata, "GENRE="+track.Genres)
-	}
-	if track.Media != "" {
-		metadata = append(metadata, "MEDIA="+track.Media)
-	}
-	if track.TrackNumber != 0 {
-		metadata = append(metadata, fmt.Sprintf("TRACKNUMBER=%d", track.TrackNumber))
-	}
-	if track.TrackTotal != 0 {
-		metadata = append(metadata, fmt.Sprintf("TRACKTOTAL=%d", track.TrackTotal))
-	}
-	if track.DiscNumber != 0 {
-		metadata = append(metadata, fmt.Sprintf("DISCNUMBER=%d", track.DiscNumber))
-	}
-	if track.DiscTotal != 0 {
-		metadata = append(metadata, fmt.Sprintf("DISCTOTAL=%d", track.DiscTotal))
-	}
-	for _, isrc := range track.ISRCs {
-		if isrc != "" {
-			metadata = append(metadata, "ISRC="+isrc)
-		}
-	}
-	if track.MusicBrainzReleaseGroupID != "" {
-		metadata = append(metadata, "MUSICBRAINZ_RELEASEGROUPID="+track.MusicBrainzReleaseGroupID)
-	}
-	if track.MusicBrainzAlbumArtistID != "" {
-		metadata = append(metadata, "MUSICBRAINZ_ALBUMARTISTID="+track.MusicBrainzAlbumArtistID)
-	}
-	if track.MusicBrainzTrackID != "" {
-		metadata = append(metadata, "MUSICBRAINZ_TRACKID="+track.MusicBrainzTrackID)
-	}
-	if track.MusicBrainzAlbumID != "" {
-		metadata = append(metadata, "MUSICBRAINZ_ALBUMID="+track.MusicBrainzAlbumID)
-	}
-	if track.MusicBrainzReleaseTrackID != "" {
-		metadata = append(metadata, "MUSICBRAINZ_RELEASETRACKID="+track.MusicBrainzReleaseTrackID)
-	}
-	if track.MusicBrainzArtistID != "" {
-		metadata = append(metadata, "MUSICBRAINZ_ARTISTID="+track.MusicBrainzArtistID)
-	}
+	metadata := util.BuildffmpegMetadata(track)
 
 	var cmd *ffmpeg.Stream
 

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -209,6 +209,9 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 	if track.AlbumArtist != "" {
 		metadata = append(metadata, "ALBUMARTIST="+track.AlbumArtist)
 	}
+	if track.ArtistSort != "" {
+		metadata = append(metadata, "ARTISTSORT="+track.ArtistSort)
+	}
 	if track.OriginalDate != "" {
 		metadata = append(metadata, "ORIGINALDATE="+track.OriginalDate)
 	}
@@ -226,6 +229,21 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 	}
 	if track.Genres != "" {
 		metadata = append(metadata, "GENRE="+track.Genres)
+	}
+	if track.Media != "" {
+		metadata = append(metadata, "MEDIA="+track.Media)
+	}
+	if track.TrackNumber != 0 {
+		metadata = append(metadata, fmt.Sprintf("TRACKNUMBER=%d", track.TrackNumber))
+	}
+	if track.TrackTotal != 0 {
+		metadata = append(metadata, fmt.Sprintf("TRACKTOTAL=%d", track.TrackTotal))
+	}
+	if track.DiscNumber != 0 {
+		metadata = append(metadata, fmt.Sprintf("DISCNUMBER=%d", track.DiscNumber))
+	}
+	if track.DiscTotal != 0 {
+		metadata = append(metadata, fmt.Sprintf("DISCTOTAL=%d", track.DiscTotal))
 	}
 	for _, isrc := range track.ISRCs {
 		if isrc != "" {

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -106,7 +106,9 @@ func queryYTMusic(track *models.Track, query string) error {
 
 	slog.Debug(fmt.Sprintf("Querying YTMusic for track %s", query))
 
-	cmd := exec.Command("python3", "search_ytmusic.py", query, "1")
+	// Use the absolute path to the search script
+	scriptPath := filepath.Join("src", "downloader", "youtube_music", "search_ytmusic.py")
+	cmd := exec.Command("python3", scriptPath, query, "1")
 
 	out, err := cmd.Output()
 	if err != nil {
@@ -131,7 +133,7 @@ func queryYTMusic(track *models.Track, query string) error {
 func (c *Youtube) GetTrack(track *models.Track) error {
 	ctx := context.Background() // ctx for yt-dlp
 
-	track.File = fmt.Sprintf("%s.%s",getFilename(track.Title, track.Artist), c.Cfg.FileExtension)
+	track.File = fmt.Sprintf("%s.%s", getFilename(track.Title, track.Artist), c.Cfg.FileExtension)
 	track.Present = fetchAndSaveVideo(ctx, *c, *track)
 
 	if track.Present {
@@ -247,7 +249,7 @@ func (c *Youtube) gatherVideo(cfg cfg.Youtube, videos Videos, track models.Track
 func fetchAndSaveVideo(ctx context.Context, cfg Youtube, track models.Track) bool {
 	stream, err := getVideo(ctx, cfg, track.ID)
 	if err != nil {
-		slog.Error("failed getting stream for video", "trackID",track.ID, "context", err.Error())
+		slog.Error("failed getting stream for video", "trackID", track.ID, "context", err.Error())
 		return false
 	}
 

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -225,11 +225,22 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 		metadata = append(metadata, "MUSICBRAINZ_ARTISTID="+track.MusicBrainzArtistID)
 	}
 
-	cmd := ffmpeg.Input(input).Output(filepath.Join(c.DownloadDir, track.File), ffmpeg.KwArgs{
-		"map":      "0:a",
-		"metadata": metadata,
-		"loglevel": "error",
-	}).OverWriteOutput().ErrorToStdOut()
+	var cmd *ffmpeg.Stream
+
+	if c.Cfg.EmbedCoverArt {
+		util.DownloadCover(track.CoverURL, c.DownloadDir)
+		coverPath := filepath.Join(c.DownloadDir, track.MusicBrainzAlbumID+".jpg")
+		cmd = ffmpeg.Output([]*ffmpeg.Stream{ffmpeg.Input(input), ffmpeg.Input(coverPath)}, filepath.Join(c.DownloadDir, track.File), ffmpeg.KwArgs{
+			"metadata": metadata,
+			"loglevel": "error",
+		}).OverWriteOutput().ErrorToStdOut()
+	} else {
+		cmd = ffmpeg.Input(input).Output(filepath.Join(c.DownloadDir, track.File), ffmpeg.KwArgs{
+			"map":      "0:a",
+			"metadata": metadata,
+			"loglevel": "error",
+		}).OverWriteOutput().ErrorToStdOut()
+	}
 
 	if c.Cfg.FfmpegPath != "" {
 		cmd.SetFfmpegPath(c.Cfg.FfmpegPath)

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -206,6 +206,32 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 	}
 
 	metadata := []string{"ARTIST=" + track.Artist, "TITLE=" + track.Title, "ALBUM=" + track.Album}
+	if track.AlbumArtist != "" {
+		metadata = append(metadata, "ALBUMARTIST="+track.AlbumArtist)
+	}
+	if track.OriginalDate != "" {
+		metadata = append(metadata, "ORIGINALDATE="+track.OriginalDate)
+	}
+	if track.OriginalYear != 0 {
+		metadata = append(metadata, fmt.Sprintf("ORIGINALYEAR=%d", track.OriginalYear))
+	}
+	if track.ReleaseCountry != "" {
+		metadata = append(metadata, "RELEASECOUNTRY="+track.ReleaseCountry)
+	}
+	if track.ReleaseStatus != "" {
+		metadata = append(metadata, "RELEASESTATUS="+track.ReleaseStatus)
+	}
+	if track.ReleaseType != "" {
+		metadata = append(metadata, "RELEASETYPE="+track.ReleaseType)
+	}
+	if track.Genres != "" {
+		metadata = append(metadata, "GENRE="+track.Genres)
+	}
+	for _, isrc := range track.ISRCs {
+		if isrc != "" {
+			metadata = append(metadata, "ISRC="+isrc)
+		}
+	}
 	if track.MusicBrainzReleaseGroupID != "" {
 		metadata = append(metadata, "MUSICBRAINZ_RELEASEGROUPID="+track.MusicBrainzReleaseGroupID)
 	}

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -106,9 +106,7 @@ func queryYTMusic(track *models.Track, query string) error {
 
 	slog.Debug(fmt.Sprintf("Querying YTMusic for track %s", query))
 
-	// Use the absolute path to the search script
-	scriptPath := filepath.Join("src", "downloader", "youtube_music", "search_ytmusic.py")
-	cmd := exec.Command("python3", scriptPath, query, "1")
+	cmd := exec.Command("python3", "search_ytmusic.py", query, "1")
 
 	out, err := cmd.Output()
 	if err != nil {

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -205,9 +205,29 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 		return false
 	}
 
+	metadata := []string{"ARTIST=" + track.Artist, "TITLE=" + track.Title, "ALBUM=" + track.Album}
+	if track.MusicBrainzReleaseGroupID != "" {
+		metadata = append(metadata, "MUSICBRAINZ_RELEASEGROUPID="+track.MusicBrainzReleaseGroupID)
+	}
+	if track.MusicBrainzAlbumArtistID != "" {
+		metadata = append(metadata, "MUSICBRAINZ_ALBUMARTISTID="+track.MusicBrainzAlbumArtistID)
+	}
+	if track.MusicBrainzTrackID != "" {
+		metadata = append(metadata, "MUSICBRAINZ_TRACKID="+track.MusicBrainzTrackID)
+	}
+	if track.MusicBrainzAlbumID != "" {
+		metadata = append(metadata, "MUSICBRAINZ_ALBUMID="+track.MusicBrainzAlbumID)
+	}
+	if track.MusicBrainzReleaseTrackID != "" {
+		metadata = append(metadata, "MUSICBRAINZ_RELEASETRACKID="+track.MusicBrainzReleaseTrackID)
+	}
+	if track.MusicBrainzArtistID != "" {
+		metadata = append(metadata, "MUSICBRAINZ_ARTISTID="+track.MusicBrainzArtistID)
+	}
+
 	cmd := ffmpeg.Input(input).Output(filepath.Join(c.DownloadDir, track.File), ffmpeg.KwArgs{
 		"map":      "0:a",
-		"metadata": []string{"artist=" + track.Artist, "title=" + track.Title, "album=" + track.Album},
+		"metadata": metadata,
 		"loglevel": "error",
 	}).OverWriteOutput().ErrorToStdOut()
 

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -45,8 +45,12 @@ func main() {
 	setup(&cfg)
 	slog.Info("Starting Explo...")
 
+	if err := os.MkdirAll(cfg.DownloadCfg.Youtube.CoversDir, 0755); err != nil {
+		slog.Error("failed making directory", "msg", err.Error())
+	}
+
 	if cfg.ServerCfg.Enabled {
-		
+
 		exploPath, err := os.Executable()
 		if err != nil {
 			log.Fatal("could not determine executable path: ", err)

--- a/src/models/types.go
+++ b/src/models/types.go
@@ -4,10 +4,14 @@ package models
 
 type Track struct {
 	Album                     string
+	AlbumArtist               string
 	ID                        string
 	Artist                    string // All artists as returned by LB
 	MainArtist                string
 	MainArtistID              string
+	ReleaseCountry            string
+	ReleaseStatus             string
+	ReleaseType               string
 	CleanTitle                string // Title as returned by LB
 	Title                     string // Title as built in listenbrainz.go
 	File                      string // File name
@@ -15,6 +19,10 @@ type Track struct {
 	Present                   bool   // is track present in the system or not
 	Duration                  int    // Track duration in milliseconds (not available for every track)
 	CoverURL                  string // External cover art URL (Cover Art Archive), used at run-time to download art
+	OriginalDate              string
+	OriginalYear              int
+	Genres                    string
+	ISRCs                     []string
 	MusicBrainzReleaseGroupID string
 	MusicBrainzAlbumArtistID  string
 	MusicBrainzTrackID        string

--- a/src/models/types.go
+++ b/src/models/types.go
@@ -9,6 +9,7 @@ type Track struct {
 	Artist                    string // All artists as returned by LB
 	MainArtist                string
 	MainArtistID              string
+	ArtistSort                string
 	ReleaseCountry            string
 	ReleaseStatus             string
 	ReleaseType               string
@@ -23,6 +24,11 @@ type Track struct {
 	OriginalYear              int
 	Genres                    string
 	ISRCs                     []string
+	Media                     string // Media format (e.g., CD, Digital Media)
+	TrackNumber               int    // Track position in media
+	TrackTotal                int    // Total tracks in media
+	DiscNumber                int    // Disc/media position
+	DiscTotal                 int    // Total discs/media
 	MusicBrainzReleaseGroupID string
 	MusicBrainzAlbumArtistID  string
 	MusicBrainzTrackID        string

--- a/src/models/types.go
+++ b/src/models/types.go
@@ -7,6 +7,7 @@ type Track struct {
 	AlbumArtist               string
 	ID                        string
 	Artist                    string // All artists as returned by LB
+	Artists                   []string
 	MainArtist                string
 	MainArtistID              string
 	ArtistSort                string

--- a/src/models/types.go
+++ b/src/models/types.go
@@ -3,16 +3,22 @@ package models
 // for structs used across the project
 
 type Track struct {
-	Album        string
-	ID           string
-	Artist       string // All artists as returned by LB
-	MainArtist   string
-	MainArtistID string
-	CleanTitle   string // Title as returned by LB
-	Title        string // Title as built in listenbrainz.go
-	File         string // File name
-	Size         int    // File size
-	Present      bool   // is track present in the system or not
-	Duration     int    // Track duration in milliseconds (not available for every track)
-	CoverURL     string // External cover art URL (Cover Art Archive), used at run-time to download art
+	Album                     string
+	ID                        string
+	Artist                    string // All artists as returned by LB
+	MainArtist                string
+	MainArtistID              string
+	CleanTitle                string // Title as returned by LB
+	Title                     string // Title as built in listenbrainz.go
+	File                      string // File name
+	Size                      int    // File size
+	Present                   bool   // is track present in the system or not
+	Duration                  int    // Track duration in milliseconds (not available for every track)
+	CoverURL                  string // External cover art URL (Cover Art Archive), used at run-time to download art
+	MusicBrainzReleaseGroupID string
+	MusicBrainzAlbumArtistID  string
+	MusicBrainzTrackID        string
+	MusicBrainzAlbumID        string
+	MusicBrainzReleaseTrackID string
+	MusicBrainzArtistID       string
 }

--- a/src/util/http.go
+++ b/src/util/http.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"explo/src/logging"
@@ -16,7 +19,7 @@ type HttpClientConfig struct {
 }
 
 type HttpClient struct {
-	Client *http.Client
+	Client    *http.Client
 	UserAgent string
 }
 
@@ -73,4 +76,35 @@ func ParseResp[T any](body []byte, target *T) error {
 		return fmt.Errorf("error unmarshaling response body: %s", err.Error())
 	}
 	return nil
+}
+
+// DownloadCover downloads coverURL into coversDir and returns "/api/covers/<mbid>.jpg".
+// Returns "" if url is empty.
+func DownloadCover(url, coversDir string) string {
+	if url == "" {
+		return ""
+	}
+	parts := strings.Split(strings.TrimRight(url, "/"), "/")
+	mbid := parts[len(parts)-2]
+	destPath := filepath.Join(coversDir, mbid+".jpg")
+	if _, err := os.Stat(destPath); os.IsNotExist(err) {
+		resp, err := http.Get(url) //nolint:noctx
+		if err == nil {
+			func() {
+				defer func() {
+					if cerr := resp.Body.Close(); cerr != nil {
+						slog.Error("failed to close cover response", "err", cerr.Error())
+					}
+				}()
+				if resp.StatusCode == http.StatusOK {
+					if data, err := io.ReadAll(resp.Body); err == nil {
+						if err := os.WriteFile(destPath, data, 0644); err != nil {
+							slog.Error("failed writing cover", "path", destPath, "err", err.Error())
+						}
+					}
+				}
+			}()
+		}
+	}
+	return "/api/covers/" + mbid + ".jpg"
 }

--- a/src/util/metadata.go
+++ b/src/util/metadata.go
@@ -3,6 +3,7 @@ package util
 import (
 	"explo/src/models"
 	"fmt"
+	"strings"
 )
 
 // Return absolute difference between tracks
@@ -30,34 +31,36 @@ func addIntTag(metadata []string, key string, value int) []string {
 func BuildffmpegMetadata(track models.Track) []string {
 	metadata := []string{}
 
-	metadata = addStringTag(metadata, "artist", track.Artist)
+	if len(track.Artists) > 0 {
+		metadata = append(metadata, "artist="+strings.Join(track.Artists, "; "))
+	} else {
+		metadata = addStringTag(metadata, "artist", track.Artist)
+	}
+
 	metadata = addStringTag(metadata, "title", track.Title)
 	metadata = addStringTag(metadata, "album", track.Album)
 	metadata = addStringTag(metadata, "album_artist", track.AlbumArtist)
 	metadata = addStringTag(metadata, "artist-sort", track.ArtistSort)
-	metadata = addStringTag(metadata, "ORIGINALDATE", track.OriginalDate)
-	metadata = addStringTag(metadata, "RELEASECOUNTRY", track.ReleaseCountry)
-	metadata = addStringTag(metadata, "RELEASESTATUS", track.ReleaseStatus)
-	metadata = addStringTag(metadata, "RELEASETYPE", track.ReleaseType)
+	metadata = addStringTag(metadata, "date", track.OriginalDate)
 	metadata = addStringTag(metadata, "genre", track.Genres)
 	metadata = addStringTag(metadata, "media", track.Media)
-	metadata = addStringTag(metadata, "MUSICBRAINZ_RELEASEGROUPID", track.MusicBrainzReleaseGroupID)
-	metadata = addStringTag(metadata, "MUSICBRAINZ_ALBUMARTISTID", track.MusicBrainzAlbumArtistID)
-	metadata = addStringTag(metadata, "MUSICBRAINZ_TRACKID", track.MusicBrainzTrackID)
-	metadata = addStringTag(metadata, "MUSICBRAINZ_ALBUMID", track.MusicBrainzAlbumID)
-	metadata = addStringTag(metadata, "MUSICBRAINZ_RELEASETRACKID", track.MusicBrainzReleaseTrackID)
-	metadata = addStringTag(metadata, "MUSICBRAINZ_ARTISTID", track.MusicBrainzArtistID)
+	metadata = addStringTag(metadata, "MusicBrainz Album Type", track.ReleaseType)
+	metadata = addStringTag(metadata, "MusicBrainz Album Status", track.ReleaseStatus)
+	metadata = addStringTag(metadata, "MusicBrainz Release Group Id", track.MusicBrainzReleaseGroupID)
+	metadata = addStringTag(metadata, "MusicBrainz Album Artist Id", track.MusicBrainzAlbumArtistID)
+	metadata = addStringTag(metadata, "MusicBrainz Track Id", track.MusicBrainzTrackID)
+	metadata = addStringTag(metadata, "MusicBrainz Album Id", track.MusicBrainzAlbumID)
+	metadata = addStringTag(metadata, "MusicBrainz Release Track Id", track.MusicBrainzReleaseTrackID)
+	metadata = addStringTag(metadata, "MusicBrainz Artist Id", track.MusicBrainzArtistID)
 
-	metadata = addIntTag(metadata, "ORIGINALYEAR", track.OriginalYear)
-	metadata = addIntTag(metadata, "TRACKNUMBER", track.TrackNumber)
-	metadata = addIntTag(metadata, "TRACKTOTAL", track.TrackTotal)
-	metadata = addIntTag(metadata, "DISCNUMBER", track.DiscNumber)
-	metadata = addIntTag(metadata, "DISCTOTAL", track.DiscTotal)
+	metadata = addIntTag(metadata, "originalyear", track.OriginalYear)
+	metadata = addIntTag(metadata, "track", track.TrackNumber)
+	metadata = addIntTag(metadata, "Tracktotal", track.TrackTotal)
+	metadata = addIntTag(metadata, "disc", track.DiscNumber)
+	metadata = addIntTag(metadata, "Disctotal", track.DiscTotal)
 
 	for _, isrc := range track.ISRCs {
-		if isrc != "" {
-			metadata = append(metadata, "ISRC="+isrc)
-		}
+		metadata = addStringTag(metadata, "ISRC", isrc)
 	}
 
 	return metadata

--- a/src/util/metadata.go
+++ b/src/util/metadata.go
@@ -1,9 +1,64 @@
 package util
 
+import (
+	"explo/src/models"
+	"fmt"
+)
+
 // Return absolute difference between tracks
 func Abs(x int) int {
 	if x < 0 {
 		return -x
 	}
 	return x
+}
+
+func addStringTag(metadata []string, key string, value string) []string {
+	if value != "" {
+		metadata = append(metadata, key+"="+value)
+	}
+	return metadata
+}
+
+func addIntTag(metadata []string, key string, value int) []string {
+	if value != 0 {
+		metadata = append(metadata, fmt.Sprintf("%s=%d", key, value))
+	}
+	return metadata
+}
+
+func BuildffmpegMetadata(track models.Track) []string {
+	metadata := []string{}
+
+	metadata = addStringTag(metadata, "artist", track.Artist)
+	metadata = addStringTag(metadata, "title", track.Title)
+	metadata = addStringTag(metadata, "album", track.Album)
+	metadata = addStringTag(metadata, "album_artist", track.AlbumArtist)
+	metadata = addStringTag(metadata, "artist-sort", track.ArtistSort)
+	metadata = addStringTag(metadata, "ORIGINALDATE", track.OriginalDate)
+	metadata = addStringTag(metadata, "RELEASECOUNTRY", track.ReleaseCountry)
+	metadata = addStringTag(metadata, "RELEASESTATUS", track.ReleaseStatus)
+	metadata = addStringTag(metadata, "RELEASETYPE", track.ReleaseType)
+	metadata = addStringTag(metadata, "genre", track.Genres)
+	metadata = addStringTag(metadata, "media", track.Media)
+	metadata = addStringTag(metadata, "MUSICBRAINZ_RELEASEGROUPID", track.MusicBrainzReleaseGroupID)
+	metadata = addStringTag(metadata, "MUSICBRAINZ_ALBUMARTISTID", track.MusicBrainzAlbumArtistID)
+	metadata = addStringTag(metadata, "MUSICBRAINZ_TRACKID", track.MusicBrainzTrackID)
+	metadata = addStringTag(metadata, "MUSICBRAINZ_ALBUMID", track.MusicBrainzAlbumID)
+	metadata = addStringTag(metadata, "MUSICBRAINZ_RELEASETRACKID", track.MusicBrainzReleaseTrackID)
+	metadata = addStringTag(metadata, "MUSICBRAINZ_ARTISTID", track.MusicBrainzArtistID)
+
+	metadata = addIntTag(metadata, "ORIGINALYEAR", track.OriginalYear)
+	metadata = addIntTag(metadata, "TRACKNUMBER", track.TrackNumber)
+	metadata = addIntTag(metadata, "TRACKTOTAL", track.TrackTotal)
+	metadata = addIntTag(metadata, "DISCNUMBER", track.DiscNumber)
+	metadata = addIntTag(metadata, "DISCTOTAL", track.DiscTotal)
+
+	for _, isrc := range track.ISRCs {
+		if isrc != "" {
+			metadata = append(metadata, "ISRC="+isrc)
+		}
+	}
+
+	return metadata
 }

--- a/src/util/metadata.go
+++ b/src/util/metadata.go
@@ -43,7 +43,7 @@ func BuildffmpegMetadata(track models.Track) []string {
 	metadata = addStringTag(metadata, "artist-sort", track.ArtistSort)
 	metadata = addStringTag(metadata, "date", track.OriginalDate)
 	metadata = addStringTag(metadata, "genre", track.Genres)
-	metadata = addStringTag(metadata, "media", track.Media)
+	metadata = addStringTag(metadata, "TMED", track.Media)
 	metadata = addStringTag(metadata, "MusicBrainz Album Type", track.ReleaseType)
 	metadata = addStringTag(metadata, "MusicBrainz Album Status", track.ReleaseStatus)
 	metadata = addStringTag(metadata, "MusicBrainz Release Group Id", track.MusicBrainzReleaseGroupID)

--- a/src/web/backend/playlists.go
+++ b/src/web/backend/playlists.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"explo/src/discovery"
 	"explo/src/models"
+	"explo/src/util"
 	"fmt"
 	"image"
 	_ "image/jpeg"
@@ -201,7 +202,7 @@ func WritePlaylistCache(cfgPath, playlist string, tracks []*models.Track, added 
 
 	ct := make([]cachedTrack, len(tracks))
 	for i, t := range tracks {
-		localCover := downloadCover(t.CoverURL, coversDir)
+		localCover := util.DownloadCover(t.CoverURL, coversDir)
 		var inLibrary *bool
 		if added != nil {
 			v := added[t.CleanTitle+"|"+t.Artist]
@@ -245,37 +246,6 @@ func lbGet(url string) ([]byte, error) {
 		return nil, fmt.Errorf("LB returned %d", resp.StatusCode)
 	}
 	return io.ReadAll(resp.Body)
-}
-
-// downloadCover downloads coverURL into coversDir and returns "/api/covers/<mbid>.jpg".
-// Returns "" if url is empty.
-func downloadCover(url, coversDir string) string {
-	if url == "" {
-		return ""
-	}
-	parts := strings.Split(strings.TrimRight(url, "/"), "/")
-	mbid := parts[len(parts)-2]
-	destPath := filepath.Join(coversDir, mbid+".jpg")
-	if _, err := os.Stat(destPath); os.IsNotExist(err) {
-		resp, err := http.Get(url) //nolint:noctx
-		if err == nil {
-			func() {
-				defer func() {
-					if cerr := resp.Body.Close(); cerr != nil {
-						slog.Error("failed to close cover response", "err", cerr.Error())
-					}
-				}()
-				if resp.StatusCode == http.StatusOK {
-					if data, err := io.ReadAll(resp.Body); err == nil {
-						if err := os.WriteFile(destPath, data, 0644); err != nil {
-							slog.Error("failed writing cover", "path", destPath, "err", err.Error())
-						}
-					}
-				}
-			}()
-		}
-	}
-	return "/api/covers/" + mbid + ".jpg"
 }
 
 // handlePrefetchCovers fetches the most recent LB playlists for the given user,
@@ -361,7 +331,7 @@ func writePrefetchCache(cfgDir, playlistType string, tracks [][4]string) {
 	}
 
 	for i, t := range tracks {
-		ct[i].CoverURL = downloadCover(t[3], coversDir)
+		ct[i].CoverURL = util.DownloadCover(t[3], coversDir)
 	}
 	if writeTrackCache(cfgDir, playlistType, ct) {
 		slog.Info("prefetch: cache updated", "playlist", playlistType, "covers", "local")

--- a/src/web/backend/playlists.go
+++ b/src/web/backend/playlists.go
@@ -167,8 +167,12 @@ func fetchMostRecentLBPlaylist(username, playlistType string) ([][4]string, time
 		meta := t.Extension.JspfTrack.AdditionalMetadata
 		var cover string
 		if meta.CaaReleaseMbid != "" && meta.CaaID != 0 {
-			cover = fmt.Sprintf("https://coverartarchive.org/release/%s/%d-250.jpg",
-				meta.CaaReleaseMbid, meta.CaaID)
+			coverSize := os.Getenv("COVERART_SIZE")
+			if coverSize == "" {
+				coverSize = "250"
+			}
+			cover = fmt.Sprintf("https://coverartarchive.org/release/%s/%d-%s.jpg",
+				meta.CaaReleaseMbid, meta.CaaID, coverSize)
 		}
 		out = append(out, [4]string{t.Title, t.Creator, t.Album, cover})
 	}

--- a/src/web/sample.env
+++ b/src/web/sample.env
@@ -51,6 +51,8 @@ LIBRARY_NAME=
 YOUTUBE_API_KEY=
 # Custom file extension for tracks (e.g mp3) (default: opus)
 # TRACK_EXTENSION=opus
+# Include cover art in downloaded files (default: false)
+# EMBED_COVER_ART=false
 # Custom path to ffmpeg binary (default: defined in $PATH)
 # FFMPEG_PATH=
 # Custom path to yt-dlp binary (default: defined in $PATH)

--- a/src/web/sample.env
+++ b/src/web/sample.env
@@ -6,6 +6,8 @@
 LISTENBRAINZ_USER=
 # 'playlist' to fetch weekly playlist (50 songs), 'api' for fewer songs (good for testing) (default: playlist)
 # LISTENBRAINZ_DISCOVERY=playlist
+# Size of the cover art downloaded from coverartarchive (250 or 500) (default: 250)
+# COVERART_SIZE=250
 
 # === Music System Configuration ===
 

--- a/src/web/sample.env
+++ b/src/web/sample.env
@@ -8,6 +8,8 @@ LISTENBRAINZ_USER=
 # LISTENBRAINZ_DISCOVERY=playlist
 # Size of the cover art downloaded from coverartarchive (250 or 500) (default: 250)
 # COVERART_SIZE=250
+# Enrich playlist tracks with full metadata from metadata/recording endpoint (default: false)
+# ENRICH_PLAYLIST_METADATA=false
 
 # === Music System Configuration ===
 


### PR DESCRIPTION
Listeinbrainz works best with MBID, so I believe it's important to try to keep local tracks with as much metadata as possible. I tried making a implementation to build metadata similar to [Picard](https://github.com/metabrainz/picard).

Changes:
- [x] New .env configuration `COVERART_SIZE` (250, 500, 1200): users can choose cover art quality according to [coverartarchive](https://musicbrainz.org/doc/Cover_Art_Archive/API) options
- [x] New .env configuration `ENRICH_PLAYLIST_METADATA` (true, false): choose to add more metadata when downloading a playlist 
- [x] New .env configuration `EMBED_COVER_ART` (true, false): choose to include cover art in each track file
- [x] Moved downloadCover to utils
- [x] Main function creates covers directory
- [x] GET `https://api.listenbrainz.org/1/metadata/recording/?recording_mbids=%s&inc=release+artist+tag+release_group+recording` fills part of the data
- [x] GET `https://musicbrainz.org/ws/2/recording/%s?inc=media+releases+artist-credits+release-groups&fmt=json` fills the rest (i couldn't find only one request to get everything)

The cli and the web are supposed to use the same folder for cover files for easier cleanup
