### PR TITLE
Limit Plex searching to music libraries, add --search-mbid flag for testing

### DIFF
--- a/src/client/plex.go
+++ b/src/client/plex.go
@@ -36,6 +36,7 @@ type Libraries struct {
 		Library   []struct {
 			Title    string `json:"title"`
 			Key      string `json:"key"`
+			Type     string `json:"type"`
 			Location []struct {
 				ID   int    `json:"id"`
 				Path string `json:"path"`
@@ -44,40 +45,39 @@ type Libraries struct {
 	} `json:"MediaContainer"`
 }
 
-type PlexSearch struct {
+type PlexTrackMetadata struct {
+	LibrarySectionTitle string `json:"librarySectionTitle"`
+	RatingKey           string `json:"ratingKey"`
+	Key                 string `json:"key"`
+	Type                string `json:"type"`
+	Title               string `json:"title"`            // Track
+	GrandparentTitle    string `json:"grandparentTitle"` // Artist
+	ParentTitle         string `json:"parentTitle"`      // Album
+	OriginalTitle       string `json:"originalTitle"`
+	Summary             string `json:"summary"`
+	Duration            int    `json:"duration"`
+	AddedAt             int    `json:"addedAt"`
+	UpdatedAt           int    `json:"updatedAt"`
+	Media               []struct {
+		ID       int `json:"id"`
+		Duration int `json:"duration"`
+		Part     []struct {
+			ID       int    `json:"id"`
+			Key      string `json:"key"`
+			Duration int    `json:"duration"`
+			File     string `json:"file"`
+			Size     int    `json:"size"`
+		} `json:"Part"`
+		AudioChannels int    `json:"audioChannels"`
+		AudioCodec    string `json:"audioCodec"`
+		Container     string `json:"container"`
+	} `json:"Media"`
+}
+
+type PlexLibraryItems struct {
 	MediaContainer struct {
-		Size         int `json:"size"`
-		SearchResult []struct {
-			Score    float64 `json:"score"`
-			Metadata struct {
-				LibrarySectionTitle string `json:"librarySectionTitle"`
-				RatingKey           string `json:"ratingKey"`
-				Key                 string `json:"key"`
-				Type                string `json:"type"`
-				Title               string `json:"title"`            // Track
-				GrandparentTitle    string `json:"grandparentTitle"` // Artist
-				ParentTitle         string `json:"parentTitle"`      // Album
-				OriginalTitle       string `json:"originalTitle"`
-				Summary             string `json:"summary"`
-				Duration            int    `json:"duration"`
-				AddedAt             int    `json:"addedAt"`
-				UpdatedAt           int    `json:"updatedAt"`
-				Media               []struct {
-					ID       int `json:"id"`
-					Duration int `json:"duration"`
-					Part     []struct {
-						ID       int    `json:"id"`
-						Key      string `json:"key"`
-						Duration int    `json:"duration"`
-						File     string `json:"file"`
-						Size     int    `json:"size"`
-					} `json:"Part"`
-					AudioChannels int    `json:"audioChannels"`
-					AudioCodec    string `json:"audioCodec"`
-					Container     string `json:"container"`
-				} `json:"Media"`
-			} `json:"Metadata"`
-		} `json:"SearchResult"`
+		Size     int                  `json:"size"`
+		Metadata []PlexTrackMetadata  `json:"Metadata"`
 	} `json:"MediaContainer"`
 }
 
@@ -111,10 +111,11 @@ type PlexPlaylist struct {
 }
 
 type Plex struct {
-	machineID  string
-	LibraryID  string
-	HttpClient *util.HttpClient
-	Cfg        config.ClientConfig
+	machineID       string
+	LibraryID       string
+	musicSectionIDs []string
+	HttpClient      *util.HttpClient
+	Cfg             config.ClientConfig
 }
 
 func NewPlex(cfg config.ClientConfig, httpClient *util.HttpClient) *Plex {
@@ -184,10 +185,15 @@ func (c *Plex) GetLibrary() error {
 	}
 
 	for _, library := range libraries.MediaContainer.Library {
+		if library.Type == "artist" {
+			c.musicSectionIDs = append(c.musicSectionIDs, library.Key)
+		}
 		if c.Cfg.LibraryName == library.Title {
 			c.LibraryID = library.Key
-			return nil
 		}
+	}
+	if c.LibraryID != "" {
+		return nil
 	}
 	if err = c.AddLibrary(); err != nil {
 		slog.Debug(err.Error())
@@ -227,20 +233,7 @@ func (c *Plex) CheckRefreshState() bool {
 
 func (c *Plex) SearchSongs(tracks []*models.Track) error {
 	for _, track := range tracks {
-		params := fmt.Sprintf("/library/search?query=%s", url.QueryEscape(track.CleanTitle))
-
-		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+params, nil, c.Cfg.Creds.Headers)
-		if err != nil {
-			slog.Warn("search request failed for '%s': %s", track.Title, err.Error())
-			continue
-		}
-
-		var searchResults PlexSearch
-		if err = util.ParseResp(body, &searchResults); err != nil {
-			slog.Warn("failed to parse response for '%s': %s", track.Title, err.Error())
-			continue
-		}
-		key, err := getPlexSong(track, searchResults)
+		key, err := c.findTrackAcrossSections(track)
 		if err != nil {
 			slog.Debug(err.Error())
 			continue
@@ -251,6 +244,30 @@ func (c *Plex) SearchSongs(tracks []*models.Track) error {
 		}
 	}
 	return nil
+}
+
+// findTrackAcrossSections searches every music library section for the given track,
+// returning the Plex key of the first match. Using per-section /all?type=10 avoids
+// the global search endpoint, which ignores the type filter and floods results with
+// TV/movie episodes that happen to share the track title.
+func (c *Plex) findTrackAcrossSections(track *models.Track) (string, error) {
+	for _, sectionID := range c.musicSectionIDs {
+		params := fmt.Sprintf("/library/sections/%s/all?type=10&title=%s", sectionID, url.QueryEscape(track.CleanTitle))
+		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+params, nil, c.Cfg.Creds.Headers)
+		if err != nil {
+			slog.Warn("search request failed", "section", sectionID, "track", track.Title, "err", err.Error())
+			continue
+		}
+		var items PlexLibraryItems
+		if err = util.ParseResp(body, &items); err != nil {
+			slog.Warn("failed to parse search response", "section", sectionID, "track", track.Title, "err", err.Error())
+			continue
+		}
+		if key := getPlexSong(track, items.MediaContainer.Metadata); key != "" {
+			return key, nil
+		}
+	}
+	return "", fmt.Errorf("failed to find '%s' by '%s' in '%s'", track.Title, track.Artist, track.Album)
 }
 
 func (c *Plex) SearchPlaylist() error {
@@ -331,22 +348,17 @@ func (c *Plex) getServer() error {
 	return nil
 }
 
-func getPlexSong(track *models.Track, searchResults PlexSearch) (string, error) {
+func getPlexSong(track *models.Track, candidates []PlexTrackMetadata) string {
 	loweredArtist := strings.ToLower(track.MainArtist)
 
-	for _, result := range searchResults.MediaContainer.SearchResult {
-		md := result.Metadata
-		if md.Type != "track" {
-			continue
-		}
-
+	for _, md := range candidates {
 		titleMatch := strings.EqualFold(md.Title, track.Title) || strings.EqualFold(md.Title, track.CleanTitle)
 		albumMatch := strings.EqualFold(md.ParentTitle, track.Album)
 		artistMatch := strings.Contains(strings.ToLower(md.OriginalTitle), loweredArtist) || strings.Contains(strings.ToLower(md.GrandparentTitle), loweredArtist)
 
 		if titleMatch && (albumMatch || artistMatch) {
 			slog.Debug(fmt.Sprintf("matched track via metadata: %s by %s", track.Title, track.Artist))
-			return md.Key, nil
+			return md.Key
 		}
 
 		if track.File == "" || len(md.Media) == 0 || len(md.Media[0].Part) == 0 {
@@ -359,12 +371,11 @@ func getPlexSong(track *models.Track, searchResults PlexSearch) (string, error) 
 
 		if durationMatch && pathMatch {
 			slog.Debug(fmt.Sprintf("matched track via path: %s by %s", track.Title, track.Artist))
-			return md.Key, nil
+			return md.Key
 		}
 	}
 
-	slog.Debug(fmt.Sprintf("full search result: %v", searchResults.MediaContainer.SearchResult))
-	return "", fmt.Errorf("failed to find '%s' by '%s' in '%s'", track.Title, track.Artist, track.Album)
+	return ""
 }
 
 func (c *Plex) addtoPlaylist(tracks []*models.Track) {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -38,6 +38,7 @@ type Flags struct {
 	ExcludeLocal bool
 	Persist      bool
 	PersistSet   bool
+	SearchMBID   string
 }
 
 type ServerConfig struct {

--- a/src/config/flags.go
+++ b/src/config/flags.go
@@ -20,6 +20,7 @@ func (cfg *Config) GetFlags() error {
 	var downloadMode string
 	var excludeLocal bool
 	var persist bool
+	var searchMBID string
 	var showVersion bool
 	// Long flags
 	flag.StringVarP(&configPath, "config", "c", ".env", "Path of the configuration file")
@@ -28,6 +29,7 @@ func (cfg *Config) GetFlags() error {
 	flag.BoolVarP(&excludeLocal, "exclude-local", "e", false, "Exclude locally found tracks from the imported playlist")
 	flag.BoolVar(&persist, "persist", true, "Keep playlists between generations")
 	flag.BoolVarP(&showVersion, "version", "v", false, "Print version and exit")
+	flag.StringVar(&searchMBID, "search-mbid", "", "Test Plex search for a single recording MBID (resolves via ListenBrainz, then searches your library)")
 
 	flag.Parse()
 
@@ -38,16 +40,16 @@ func (cfg *Config) GetFlags() error {
 	persistSet := flag.Lookup("persist").Changed
 	cfgSet := flag.Lookup("config").Changed
 
-	// Validation for playlist
-	if !contains(validPlaylists, playlist) {
-		return fmt.Errorf("flag validation error: invalid playlist %s (must be one of: %s)",
-			playlist, strings.Join(validPlaylists, ", "))
-	}
-
-	// Validation for download mode
-	if !contains(validDownloadMode, downloadMode) {
-		return fmt.Errorf("flag validation error: invalid download mode %s (must be one of: %s)",
-			downloadMode, strings.Join(validDownloadMode, ", "))
+	// Skip normal playlist/download-mode validation when just doing a search test
+	if searchMBID == "" {
+		if !contains(validPlaylists, playlist) {
+			return fmt.Errorf("flag validation error: invalid playlist %s (must be one of: %s)",
+				playlist, strings.Join(validPlaylists, ", "))
+		}
+		if !contains(validDownloadMode, downloadMode) {
+			return fmt.Errorf("flag validation error: invalid download mode %s (must be one of: %s)",
+				downloadMode, strings.Join(validDownloadMode, ", "))
+		}
 	}
 
 	cfg.Flags.CfgPath = configPath
@@ -56,6 +58,7 @@ func (cfg *Config) GetFlags() error {
 	cfg.Flags.DownloadMode = downloadMode
 	cfg.Flags.ExcludeLocal = excludeLocal
 	cfg.Flags.Persist = persist
+	cfg.Flags.SearchMBID = searchMBID
 
 	// for deprecation purposes (can be removed at a later date)
 	cfg.Flags.PersistSet = persistSet

--- a/src/discovery/listenbrainz.go
+++ b/src/discovery/listenbrainz.go
@@ -284,6 +284,16 @@ func (c *ListenBrainz) getTracks(mbids []string, singleArtist bool) ([]*models.T
 
 }
 
+// LookupRecording resolves a single recording MBID to a Track using the same
+// LB metadata endpoint and field mapping as the normal discovery path.
+func (c *ListenBrainz) LookupRecording(mbid string) (*models.Track, error) {
+	tracks, err := c.getTracks([]string{mbid}, false)
+	if err != nil {
+		return nil, err
+	}
+	return tracks[0], nil
+}
+
 // Get user LB playlists and find wanted playlists ID
 func (c *ListenBrainz) getImportPlaylist(user string) (string, error) {
 	var offset int

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -27,6 +27,30 @@ func initHttpClient() *util.HttpClient {
 	})
 }
 
+func runSearchTest(cfg *config.Config, httpClient *util.HttpClient) {
+	lb := discovery.NewListenBrainz(cfg.DiscoveryCfg, httpClient)
+	track, err := lb.LookupRecording(cfg.Flags.SearchMBID)
+	if err != nil {
+		log.Fatalf("failed to resolve MBID %s from ListenBrainz: %s", cfg.Flags.SearchMBID, err)
+	}
+	slog.Info("resolved recording", "title", track.CleanTitle, "artist", track.MainArtist, "album", track.Album, "duration_ms", track.Duration)
+
+	c, err := client.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("failed to init client: %s", err)
+	}
+	tracks := []*models.Track{track}
+	if err := c.CheckTracks(tracks); err != nil {
+		slog.Warn("CheckTracks error", "err", err)
+	}
+
+	if track.Present {
+		slog.Info("FOUND in library", "system", cfg.System, "key", track.ID)
+	} else {
+		slog.Info("NOT FOUND in library", "system", cfg.System)
+	}
+}
+
 // Inits debug, gets playlist name, if needed, handles deprecation
 func setup(cfg *config.Config) {
 	cfg.HandleDeprecation()
@@ -43,6 +67,14 @@ func main() {
 	cfg.ReadEnv()
 	cfg.MergeFlags()
 	setup(&cfg)
+
+	httpClient := initHttpClient()
+
+	if cfg.Flags.SearchMBID != "" {
+		runSearchTest(&cfg, httpClient)
+		return
+	}
+
 	slog.Info("Starting Explo...")
 
 	if cfg.ServerCfg.Enabled {
@@ -56,7 +88,8 @@ func main() {
 		srv := backend.NewServer(cfg.ServerCfg)
 		log.Fatal(srv.Start())
 	}
-	httpClient := initHttpClient()
+
+	slog.Info("Starting Explo...")
 	discovery := discovery.NewDiscoverer(cfg.DiscoveryCfg, httpClient)
 	tracks, err := discovery.Discover()
 	if err != nil {


### PR DESCRIPTION
All the real changes are in `plex.go`, the rest was so I could add `--search-mbid` flag for verifying the change worked on a track I knew it was present for. It can also be used for debugging in the future.

### Before:
Running `docker exec -it explo sh -c "LOG_LEVEL=DEBUG /opt/explo/explo --search-mbid ced6401e-396c-4c9e-9614-7f7e1a281e39 -c /opt/explo/.env/.env"` (Searching for "Something" by The Beatles)
returned
> ❯ docker exec -it explo sh -c "LOG_LEVEL=DEBUG /opt/explo/explo --search-mbid ced6401e-396c-4c9e-9614-7f7e1a281e39 -c /opt/explo/.env/.env"
time=2026-05-19T20:16:24.386Z level=INFO msg="resolved recording" title=Something artist="The Beatles" album="Abbey Road" duration_ms=187000
time=2026-05-19T20:16:24.454Z level=DEBUG msg="full search result: [{0.71084 {TV Shows 20278 /library/metadata/20278 episode Something to Talk About Grey's Anatomy Season 2  Cristina, Izzie and Meredith take care of Shane, a man who appears to be crazy and claims that he is pregnant. Shane's case induces a spreading fascination among the staff. George relates to a patient's husband... (truncated, but very large log of lots of results)
time=2026-05-19T20:16:24.454Z level=DEBUG msg="failed to find 'Something' by 'The Beatles' in 'Abbey Road'"
time=2026-05-19T20:16:24.454Z level=INFO msg="NOT FOUND in Plex"


### After:
Same command returns:
> ❯ docker exec -it explo sh -c "LOG_LEVEL=DEBUG /opt/explo/explo --search-mbid ced6401e-396c-4c9e-9614-7f7e1a281e39 -c /opt/explo/.env/.env"
time=2026-05-19T20:18:04.215Z level=INFO msg="resolved recording" title=Something artist="The Beatles" album="Abbey Road" duration_ms=187000
time=2026-05-19T20:18:04.224Z level=DEBUG msg="matched track via metadata: Something by The Beatles"
time=2026-05-19T20:18:04.224Z level=INFO msg="FOUND in library" system=plex key=/library/metadata/26184


Closes #131 