### PR TITLE
Improve Jellyfin media server metadata handling

### DIFF
--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -127,7 +127,7 @@ func (c *Jellyfin) AddLibrary() error {
 }
 
 func (c *Jellyfin) RefreshLibrary() error {
-	reqParam := fmt.Sprintf("/Items/%s/Refresh?metadataRefreshMode=FullRefresh&Recursive=true", c.LibraryID)
+	reqParam := fmt.Sprintf("/Items/%s/Refresh?metadataRefreshMode=FullRefresh&imageRefreshMode=FullRefresh&replaceAllMetadata=false&replaceAllImages=false&Recursive=true", c.LibraryID)
 
 	if _, err := c.HttpClient.MakeRequest("POST", c.Cfg.URL+reqParam, nil, c.Cfg.Creds.Headers); err != nil {
 		return err

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -205,7 +205,7 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 
 	cmd := ffmpeg.Input(input).Output(filepath.Join(c.DownloadDir, track.File), ffmpeg.KwArgs{
 		"map":      "0:a",
-		"metadata": []string{"artist=" + track.Artist, "title=" + track.Title, "album=" + track.Album},
+		"metadata": []string{"artist=" + track.Artist, "album_artist=" + track.MainArtist, "title=" + track.Title, "album=" + track.Album},
 		"loglevel": "error",
 	}).OverWriteOutput().ErrorToStdOut()
 


### PR DESCRIPTION
Small Jellyfin-focused improvements split out from bigger proposal here: https://github.com/LumePart/Explo/pull/125

- Ask Jellyfin to refresh images when Explo triggers a library scan
- Write `album_artist` metadata for YouTube downloads, so Jellyfin groups tracks more reliably