### PR TITLE
Normalize track titles for feat. artists and punctuation, fix duplicate downloads

### DIFF
--- a/src/client/emby.go
+++ b/src/client/emby.go
@@ -139,7 +139,7 @@ func (c *Emby) SearchSongs(tracks []*models.Track) error {
 		}
 
 		for _, item := range results.Items {
-			if strings.EqualFold(track.MainArtist, item.AlbumArtist) && (strings.EqualFold(item.Name, track.CleanTitle) || (track.File != "" && strings.Contains(strings.ToLower(item.Path), strings.ToLower(track.File)))) {
+			if strings.EqualFold(track.MainArtist, item.AlbumArtist) && (util.NormalizeTitle(item.Name) == util.NormalizeTitle(track.Title) || (track.File != "" && strings.Contains(strings.ToLower(item.Path), strings.ToLower(track.File)))) {
 				track.ID = item.ID
 				track.Present = true
 				break

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -154,7 +154,7 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 		}
 
 		for _, item := range results.Items {
-			if strings.EqualFold(track.MainArtist, item.AlbumArtist) && (strings.EqualFold(item.Name, track.CleanTitle) || (track.File != "" && strings.Contains(strings.ToLower(item.Path), strings.ToLower(track.File)))) {
+			if strings.EqualFold(track.MainArtist, item.AlbumArtist) && (util.NormalizeTitle(item.Name) == util.NormalizeTitle(track.Title) || (track.File != "" && strings.Contains(strings.ToLower(item.Path), strings.ToLower(track.File)))) {
 				track.ID = item.ID
 				track.Present = true
 				break

--- a/src/client/plex.go
+++ b/src/client/plex.go
@@ -390,13 +390,13 @@ func (c *Plex) SearchSongs(tracks []*models.Track) error {
 		}
 
 		if err != nil {
-			slog.Warn("search request failed for '%s': %s", track.Title, err.Error())
+			slog.Warn("search request failed", "title", track.Title, "err", err)
 			continue
 		}
 
 		var hubResults PlexHubSearch
 		if err := util.ParseResp(body, &hubResults); err != nil {
-			slog.Warn("failed to parse hub response for '%s': %s", track.Title, err.Error())
+			slog.Warn("failed to parse hub response", "title", track.Title, "err", err)
 			continue
 		}
 
@@ -412,7 +412,7 @@ func (c *Plex) SearchSongs(tracks []*models.Track) error {
 
 		key, err := getPlexSong(track, all)
 		if err != nil {
-			slog.Warn("failed to find match for '%s': %s", track.Title, err.Error())
+			slog.Warn("failed to find match", "title", track.Title, "err", err)
 			continue
 		}
 		if key != "" {
@@ -549,7 +549,7 @@ func getPlexSong(track *models.Track, metadata []SongMetadata) (string, error) {
 			continue
 		}
 
-		titleMatch := strings.EqualFold(md.Title, track.Title) || strings.EqualFold(md.Title, track.CleanTitle)
+		titleMatch := util.NormalizeTitle(md.Title) == util.NormalizeTitle(track.Title)
 		albumMatch := strings.EqualFold(md.ParentTitle, track.Album)
 		artistMatch := strings.Contains(strings.ToLower(md.OriginalTitle), loweredArtist) || strings.Contains(strings.ToLower(md.GrandparentTitle), loweredArtist)
 
@@ -582,7 +582,7 @@ func (c *Plex) addtoPlaylist(tracks []*models.Track) {
 			params := fmt.Sprintf("/playlists/%s/items?uri=server://%s/com.plexapp.plugins.library%s", c.Cfg.PlaylistID, c.machineID, track.ID)
 
 			if _, err := c.HttpClient.MakeRequest("PUT", c.Cfg.URL+params, nil, c.Cfg.Creds.Headers); err != nil {
-				slog.Warn("failed to add %s to playlist: %s", track.Title, err.Error())
+				slog.Warn("failed to add to playlist", "title", track.Title, "err", err)
 			}
 		}
 	}

--- a/src/client/subsonic.go
+++ b/src/client/subsonic.go
@@ -146,7 +146,7 @@ func (c *Subsonic) SearchSongs(tracks []*models.Track) error {
 
 		for _, song := range songs {
 			artistMatch := strings.Contains(strings.ToLower(song.Artist), strings.ToLower(track.MainArtist))
-			titleMatch := strings.EqualFold(song.Title, track.Title) || strings.EqualFold(song.Title, track.CleanTitle)
+			titleMatch := util.NormalizeTitle(song.Title) == util.NormalizeTitle(track.Title)
 			durationMatch := util.Abs(song.Duration - (track.Duration / 1000)) < 10
 			pathMatch := strings.Contains(strings.ToLower(song.Path), strings.ToLower(track.File))
 

--- a/src/util/sanitize.go
+++ b/src/util/sanitize.go
@@ -1,11 +1,22 @@
 package util
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 var (
 	filenameRe = regexp.MustCompile(`[^\p{L}\d._,\-]+`)
 	alnumRe    = regexp.MustCompile(`[^\p{L}\d]+`)
+	featTailRe = regexp.MustCompile(`(?i)\s*[\(\[\{]\s*(feat\.?|featuring|ft\.?|with)\s[^\)\]\}]*[\)\]\}]\s*$`)
 )
+
+// NormalizeTitle strips trailing (feat. …) annotations, lowercases,
+// and reduces to alphanumeric-only for fuzzy title comparison.
+func NormalizeTitle(s string) string {
+	s = featTailRe.ReplaceAllString(s, "")
+	return AlnumOnly(strings.ToLower(s))
+}
 
 // FilenameSafe replaces characters unsafe for filenames with '_'
 func FilenameSafe(s string) string {


### PR DESCRIPTION
I noticed a lot of people were having issues with tracks getting re-downloaded, even though the track was already in their library. As it turns out, matches against the users library were failing when Listenbrainz returned titles with (feat. artist) or any sort of variation of apostrophes.  (' vs ')

So if Listenbrainz returned` BANKROLL (feat. A$AP Rocky & A$AP Ferg)`and the users track in their library didn't match this EXACT punctuation ( `BANKROLL ft. A$AP Rocky and A$AP Ferg`) explo counts this as a missing track, even if plex is smart enough to return the correct track!

Or if Listenbrainz returns a song:
`I Don't Know You` by The Marias
 but the user may have:
`I Don't Know You` by The Marias
 
(bet you cant even tell they're different lol, curly vs straight apostrophes), its still marked as a missing track, and tries to re-download the song.



This PR adds `util.NormalizeTitle ` in sanitize.go which strips` feat/ft/featuring/with` parentheticals and reduces to lowercase alphanumeric, making punctuation differences like curly vs straight apostrophes irrelevant

Also updated all four music clients to compare against the new normalized forms 

After adding this patch to my build, explo was able to match WAY more tracks from my library that were previously flagged as missing, with no more duplicate downloads.