### PR TITLE
fix for public playlist variable and jellyfin flow

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,3 +1,7 @@
+# === Web UI ===
+# Web cache limit in MB (cover art, backgrounds) (default: 500)
+# WEB_CACHE_MB=500
+
 # === Discovery Config ===
 
 # Service which recommends songs (only 'listenbrainz' is supported)
@@ -9,7 +13,7 @@ LISTENBRAINZ_USER=
 # Size of the cover art downloaded from coverartarchive (250 or 500) (default: 250)
 # COVERART_SIZE=250
 # Enrich playlist tracks with full metadata from metadata/recording endpoint (default: false)
-# ENRICH_PLAYLIST_METADATA=false
+# ENRICH_TRACK_METADATA=false
 
 # === Music System Configuration ===
 
@@ -21,9 +25,9 @@ SYSTEM_URL=
 SYSTEM_USERNAME=
 # Password for the user (required for subsonic, recommended for plex)
 SYSTEM_PASSWORD=
-# Optional admin username for systems like Navidrome/Subsonic (used only for triggering library scans)
+# Optional admin username for systems like Navidrome/Subsonic/Plex (used to trigger operations that need elevated permissions for multi-user setups)
 # ADMIN_SYSTEM_USERNAME=
-# Optional admin password for systems like Navidrome/Subsonic (used only for triggering library scans)
+# Optional admin password for systems like Navidrome/Subsonic/Plex
 # ADMIN_SYSTEM_PASSWORD=
 # API Key from your media system (required for emby and jellyfin, optional for plex)
 API_KEY=
@@ -51,8 +55,8 @@ LIBRARY_NAME=
 
 # === YouTube Configuration ===
 
-# YouTube Data API key (required if using youtube)
-YOUTUBE_API_KEY=
+# YouTube Data API key (optional, fall back is unofficial ytmusic API)
+# YOUTUBE_API_KEY=
 # Custom file extension for tracks (e.g mp3) (default: opus)
 # TRACK_EXTENSION=opus
 # Include cover art in downloaded files (default: false)

--- a/src/client/client.go
+++ b/src/client/client.go
@@ -137,7 +137,7 @@ func (c *Client) systemSetup() error {
 			return fmt.Errorf("Jellyfin API_KEY is required")
 		}
 		if c.Cfg.Creds.User == "" {
-			return fmt.Errorf("Jellyfin SYSTEM_USERNAME is required")
+			slog.Warn("It is recommended to set SYSTEM_USERNAME for Jellyfin")
 		}
 		if err := c.API.AddHeader(); err != nil {
 			return err

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -214,11 +214,18 @@ func (c *Jellyfin) CreatePlaylist(tracks []*models.Track) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal track IDs: %s", err.Error())
 	}
-	userID, err := c.ResolveUserID()
-	if err != nil {
-		return err
+	var userID string
+	isPublic := c.Cfg.PublicPlaylist
+	if c.Cfg.Creds.User != "" {
+		userID, err = c.ResolveUserID()
+		if err != nil {
+			return err
+		}
+	} else {
+		userID = c.Cfg.Creds.APIKey
+		isPublic = true
 	}
-	isPublic := c.Cfg.Subsonic.PublicPlaylist
+
 
 	queryParams := "/Playlists"
 	payload := fmt.Appendf(nil, `
@@ -243,7 +250,10 @@ func (c *Jellyfin) CreatePlaylist(tracks []*models.Track) error {
 }
 
 func (c *Jellyfin) UpdatePlaylist() error {
-	isPublic := c.Cfg.Subsonic.PublicPlaylist
+	isPublic := c.Cfg.PublicPlaylist
+	if c.Cfg.Creds.User == "" {
+		isPublic = true
+	}
 	queryParams := fmt.Sprintf("/Items/%s", c.Cfg.PlaylistID)
 	payload := fmt.Appendf(nil, `
 		{

--- a/src/client/subsonic.go
+++ b/src/client/subsonic.go
@@ -268,7 +268,7 @@ func (c *Subsonic) SearchPlaylist() error {
 }
 
 func (c *Subsonic) UpdatePlaylist() error {
-	reqParam := fmt.Sprintf("updatePlaylist?playlistId=%s&comment=%s&f=json&public=%t",c.Cfg.PlaylistID, url.QueryEscape(c.Cfg.PlaylistDescr), c.Cfg.Subsonic.PublicPlaylist)
+	reqParam := fmt.Sprintf("updatePlaylist?playlistId=%s&comment=%s&f=json&public=%t",c.Cfg.PlaylistID, url.QueryEscape(c.Cfg.PlaylistDescr), c.Cfg.PublicPlaylist)
 
 	if _, err := c.subsonicRequest(reqParam); err != nil {
 		return err

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -63,6 +63,7 @@ type ClientConfig struct {
 	PlaylistNFormat string `env:"PLAYLISTNAME_FORMAT" env-default:"week"`
 	PlaylistDescr   string
 	PlaylistID      string
+	PublicPlaylist  bool   `env:"PUBLIC_PLAYLIST" env-default:"false"`
 	Sleep           int `env:"SLEEP" env-default:"2"`
 	HTTPTimeout     int `env:"CLIENT_HTTP_TIMEOUT" env-default:"10"`
 	Creds           Credentials
@@ -87,7 +88,6 @@ type AdminCredentials struct {
 type SubsonicConfig struct {
 	Version        string `env:"SUBSONIC_VERSION" env-default:"1.16.1"`
 	ID             string `env:"CLIENT" env-default:"explo"`
-	PublicPlaylist bool   `env:"PUBLIC_PLAYLIST" env-default:"false"`
 }
 
 type DownloadConfig struct {

--- a/src/web/sample.env
+++ b/src/web/sample.env
@@ -1,3 +1,7 @@
+# === Web UI ===
+# Web cache limit in MB (cover art, backgrounds) (default: 500)
+# WEB_CACHE_MB=500
+
 # === Discovery Config ===
 
 # Service which recommends songs (only 'listenbrainz' is supported)
@@ -9,7 +13,7 @@ LISTENBRAINZ_USER=
 # Size of the cover art downloaded from coverartarchive (250 or 500) (default: 250)
 # COVERART_SIZE=250
 # Enrich playlist tracks with full metadata from metadata/recording endpoint (default: false)
-# ENRICH_PLAYLIST_METADATA=false
+# ENRICH_TRACK_METADATA=false
 
 # === Music System Configuration ===
 
@@ -21,15 +25,15 @@ SYSTEM_URL=
 SYSTEM_USERNAME=
 # Password for the user (required for subsonic, recommended for plex)
 SYSTEM_PASSWORD=
-# Optional admin username for systems like Navidrome/Subsonic (used only for triggering library scans)
+# Optional admin username for systems like Navidrome/Subsonic/Plex (used to trigger operations that need elevated permissions for multi-user setups)
 # ADMIN_SYSTEM_USERNAME=
-# Optional admin password for systems like Navidrome/Subsonic (used only for triggering library scans)
+# Optional admin password for systems like Navidrome/Subsonic/Plex
 # ADMIN_SYSTEM_PASSWORD=
 # API Key from your media system (required for emby and jellyfin, optional for plex)
 API_KEY=
 # Name of the music library in your system (emby, jellyfin, plex)
 LIBRARY_NAME=
-# Mark playlist as public (subsonic)
+# Mark playlist as public (subsonic, jellyfin)
 # PUBLIC_PLAYLIST=false
 
 # === Downloader Configuration ===
@@ -49,8 +53,8 @@ LIBRARY_NAME=
 
 # === YouTube Configuration ===
 
-# YouTube Data API key (required if using youtube)
-YOUTUBE_API_KEY=
+# YouTube Data API key (optional, fall back is unofficial ytmusic API)
+# YOUTUBE_API_KEY=
 # Custom file extension for tracks (e.g mp3) (default: opus)
 # TRACK_EXTENSION=opus
 # Include cover art in downloaded files (default: false)


### PR DESCRIPTION
Quick fix to not break existing Jellyfin setups + moved `PUBLIC_PLAYLIST` variable out of SubsonicConfig