### PR TITLE
feat(downloader): add SpotiFLAC as a download source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,15 +33,15 @@ RUN apk add --no-cache \
     shadow \
     su-exec
 
-# SpotiFLAC python module version to install (FLAC download source). Pulled from the
-# project's matching GitHub version-branch archive, since 1.2.1 (which restored the
-# upstream endpoint registry) is not on PyPI yet. Override at build time, e.g.:
-#   --build-arg SPOTIFLAC_VERSION=1.2.2
-ARG SPOTIFLAC_VERSION=1.2.1
+# SpotiFLAC version to install (FLAC download source). Installs from PyPI and puts
+# the `spotiflac` CLI on PATH. Override at build time, e.g.:
+#   --build-arg SPOTIFLAC_VERSION=1.2.4
+ARG SPOTIFLAC_VERSION=1.2.3
 
-# Install ytmusicapi (youtube fallback search) and SpotiFLAC (FLAC download source)
-RUN pip install --no-cache-dir ytmusicapi \
-    "https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version/archive/${SPOTIFLAC_VERSION}.tar.gz"
+# Install ytmusicapi (youtube fallback search) and SpotiFLAC (FLAC download source).
+# This provides both the `spotiflac` CLI (URL-based imports) and the importable
+# SpotiFLAC module used by spotiflac_dl.py (ISRC/title-artist matching).
+RUN pip install --no-cache-dir ytmusicapi "SpotiFLAC==${SPOTIFLAC_VERSION}"
 
 # Set working directory
 WORKDIR /opt/explo/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,15 @@ RUN apk add --no-cache \
     shadow \
     su-exec
 
+# SpotiFLAC python module version to install (FLAC download source). Pulled from the
+# project's matching GitHub version-branch archive, since 1.2.1 (which restored the
+# upstream endpoint registry) is not on PyPI yet. Override at build time, e.g.:
+#   --build-arg SPOTIFLAC_VERSION=1.2.2
+ARG SPOTIFLAC_VERSION=1.2.1
+
 # Install ytmusicapi (youtube fallback search) and SpotiFLAC (FLAC download source)
-RUN pip install --no-cache-dir ytmusicapi SpotiFLAC==1.2.0
+RUN pip install --no-cache-dir ytmusicapi \
+    "https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version/archive/${SPOTIFLAC_VERSION}.tar.gz"
 
 # Set working directory
 WORKDIR /opt/explo/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,16 +33,17 @@ RUN apk add --no-cache \
     shadow \
     su-exec
 
-# Install ytmusicapi in the container
-RUN pip install --no-cache-dir ytmusicapi
+# Install ytmusicapi (youtube fallback search) and SpotiFLAC (FLAC download source)
+RUN pip install --no-cache-dir ytmusicapi SpotiFLAC==1.2.0
 
 # Set working directory
 WORKDIR /opt/explo/
 
-# Copy entrypoint, binary, python helper
+# Copy entrypoint, binary, python helpers
 COPY ./docker/start.sh /start.sh
 COPY --from=builder /app/explo .
 COPY src/downloader/youtube_music/search_ytmusic.py .
+COPY src/downloader/spotiflac/spotiflac_dl.py .
 
 
 RUN chmod +x /start.sh ./explo

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,15 +33,14 @@ RUN apk add --no-cache \
     shadow \
     su-exec
 
-# SpotiFLAC version to install (FLAC download source). Installs from PyPI and puts
-# the `spotiflac` CLI on PATH. Override at build time, e.g.:
-#   --build-arg SPOTIFLAC_VERSION=1.2.4
-ARG SPOTIFLAC_VERSION=1.2.3
-
-# Install ytmusicapi (youtube fallback search) and SpotiFLAC (FLAC download source).
-# This provides both the `spotiflac` CLI (URL-based imports) and the importable
-# SpotiFLAC module used by spotiflac_dl.py (ISRC/title-artist matching).
-RUN pip install --no-cache-dir ytmusicapi "SpotiFLAC==${SPOTIFLAC_VERSION}"
+# Always install the LATEST SpotiFLAC (the FLAC download source — provides both the `spotiflac`
+# CLI and the importable module used by spotiflac_dl.py). SpotiFLAC's reverse-engineered Deezer/
+# Qobuz/etc. backends break often and are fixed upstream, so pinning goes stale fast. The ADD of
+# PyPI's release metadata busts THIS layer's build cache whenever a new SpotiFLAC version ships, so
+# a rebuild (`app.redeploy music`) re-resolves to the newest release; unchanged → fast cache hit.
+# ytmusicapi = youtube fallback search. To pin instead, use `SpotiFLAC==<ver>` below.
+ADD https://pypi.org/pypi/SpotiFLAC/json /tmp/spotiflac-pypi.json
+RUN pip install --no-cache-dir --upgrade ytmusicapi SpotiFLAC && rm -f /tmp/spotiflac-pypi.json
 
 # Set working directory
 WORKDIR /opt/explo/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Explo uses the [ListenBrainz](https://listenbrainz.org/) recommendation engine t
   - Apple Music
   - ListenBrainz
   - Spotify
-- Request tracks from YouTube, Soulseek, or both
+- Request tracks from YouTube, Soulseek, or SpotiFLAC (lossless FLAC)
 - Add metadata to downloaded tracks
 - Create playlists in your music system
 - Keep previous playlists for later listening
@@ -54,6 +54,8 @@ Explo uses the following 3rd-party libraries:
 - [godotenv](https://github.com/joho/godotenv): Load configuration from `.env` files
 
 - [ytmusicapi](https://github.com/sigma67/ytmusicapi): Unofficial Youtube Music API
+
+- [SpotiFLAC](https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version): Lossless FLAC download module
 
 - [notify](https://github.com/nikoksr/notify): Module for sending notifications to different services
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Explo uses the following 3rd-party libraries:
 
 - [ytmusicapi](https://github.com/sigma67/ytmusicapi): Unofficial Youtube Music API
 
-- [SpotiFLAC](https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version): Lossless FLAC download module
+- [SpotiFLAC](https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version): Lossless FLAC downloader (official CLI)
 
 - [notify](https://github.com/nikoksr/notify): Module for sending notifications to different services
 

--- a/sample.env
+++ b/sample.env
@@ -104,25 +104,28 @@ LIBRARY_NAME=
 
 # === SpotiFLAC Configuration ===
 
-# Downloads lossless FLAC via the SpotiFLAC python module (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version).
-# Requires python3 with the SpotiFLAC module (>=1.2.1) installed (bundled in the docker image) and ffmpeg in $PATH.
-# To build the image with a different module version: --build-arg SPOTIFLAC_VERSION=<version>
-# Add 'spotiflac' to DOWNLOAD_SERVICES to enable it.
+# Downloads lossless FLAC via SpotiFLAC (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version),
+# bundled in the docker image (pip install "SpotiFLAC>=1.2.3") with ffmpeg in $PATH.
+# To build the image with a different version: --build-arg SPOTIFLAC_VERSION=<version>
+# Add 'spotiflac' to DOWNLOAD_SERVICES to enable it. Tracks with a streaming URL
+# (Spotify-imported playlists) use the official `spotiflac` CLI; tracks matched by
+# ISRC/title-artist (e.g. ListenBrainz discovery) use the bundled module helper.
+# Tracks SpotiFLAC can't source fall through to the other configured services.
 
 # FLAC sources to try, in priority order (default: deezer,tidal,qobuz,amazon)
 # SPOTIFLAC_SOURCES=deezer,tidal,qobuz,amazon
-# Preferred quality passed to the source (leave empty to use the provider's lossless default)
+# Preferred quality for the CLI path (default: LOSSLESS; e.g. HI_RES_LOSSLESS, LOSSLESS, HIGH)
 # SPOTIFLAC_QUALITY=LOSSLESS
-# Python interpreter that has the SpotiFLAC module installed (default: python3)
+# Path to the spotiflac CLI (default: spotiflac, resolved from $PATH)
+# SPOTIFLAC_BIN=spotiflac
+# Python interpreter with the SpotiFLAC module installed, for the helper path (default: python3)
 # SPOTIFLAC_PYTHON_PATH=python3
-# Path to the bundled wrapper script (default: spotiflac_dl.py; set to an absolute path for the binary version)
+# Path to the bundled module helper (default: spotiflac_dl.py; set an absolute path for the binary version)
 # SPOTIFLAC_SCRIPT_PATH=spotiflac_dl.py
 # Max seconds to spend downloading a single track before giving up (default: 180)
 # SPOTIFLAC_TIMEOUT=180
-# Filename format used by SpotiFLAC (default: {title} - {artist})
-# SPOTIFLAC_FILENAME_FORMAT={title} - {artist}
-# Optional Qobuz auth token passthrough
-# SPOTIFLAC_QOBUZ_TOKEN=
+# Extra download attempts per track on failure, cycling all sources (default: 2)
+# SPOTIFLAC_RETRIES=2
 
 # === Metadata / Formatting ===
 

--- a/sample.env
+++ b/sample.env
@@ -105,7 +105,8 @@ LIBRARY_NAME=
 # === SpotiFLAC Configuration ===
 
 # Downloads lossless FLAC via the SpotiFLAC python module (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version).
-# Requires python3 with the SpotiFLAC module installed (bundled in the docker image) and ffmpeg in $PATH.
+# Requires python3 with the SpotiFLAC module (>=1.2.1) installed (bundled in the docker image) and ffmpeg in $PATH.
+# To build the image with a different module version: --build-arg SPOTIFLAC_VERSION=<version>
 # Add 'spotiflac' to DOWNLOAD_SERVICES to enable it.
 
 # FLAC sources to try, in priority order (default: deezer,tidal,qobuz,amazon)

--- a/sample.env
+++ b/sample.env
@@ -48,6 +48,7 @@ LIBRARY_NAME=
 # Keep original file permissions when moving files (set to false on Synology devices)
 # KEEP_PERMISSIONS=true
 # Comma-separated list (no spaces) of download services, in priority order (default: youtube)
+# Supported: youtube, slskd, spotiflac
 # DOWNLOAD_SERVICES=youtube
 # Path templating, Options are Artist, Album, TrackName, TrackNumber, File, Ext (eg. "{{Artist}}/{{Album}}/{{File}}")
 # PATH_TEMPLATING=""
@@ -100,6 +101,27 @@ LIBRARY_NAME=
 # MIN_BITRATE=256
 # Comma-separated (without spaces) keywords to avoid, when filtering slskd results (default: live,remix,instrumental,extended,clean,acapella)
 # FILTER_LIST=live,remix,instrumental,extended,clean,acapella
+
+# === SpotiFLAC Configuration ===
+
+# Downloads lossless FLAC via the SpotiFLAC python module (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version).
+# Requires python3 with the SpotiFLAC module installed (bundled in the docker image) and ffmpeg in $PATH.
+# Add 'spotiflac' to DOWNLOAD_SERVICES to enable it.
+
+# FLAC sources to try, in priority order (default: deezer,tidal,qobuz,amazon)
+# SPOTIFLAC_SOURCES=deezer,tidal,qobuz,amazon
+# Preferred quality passed to the source (leave empty to use the provider's lossless default)
+# SPOTIFLAC_QUALITY=LOSSLESS
+# Python interpreter that has the SpotiFLAC module installed (default: python3)
+# SPOTIFLAC_PYTHON_PATH=python3
+# Path to the bundled wrapper script (default: spotiflac_dl.py; set to an absolute path for the binary version)
+# SPOTIFLAC_SCRIPT_PATH=spotiflac_dl.py
+# Max seconds to spend downloading a single track before giving up (default: 180)
+# SPOTIFLAC_TIMEOUT=180
+# Filename format used by SpotiFLAC (default: {title} - {artist})
+# SPOTIFLAC_FILENAME_FORMAT={title} - {artist}
+# Optional Qobuz auth token passthrough
+# SPOTIFLAC_QOBUZ_TOKEN=
 
 # === Metadata / Formatting ===
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -142,7 +142,7 @@ type YoutubeMusic struct {
 // (PythonPath + ScriptPath). Sources is the list of FLAC providers to try in
 // priority order; see sample.env for the full reference.
 type Spotiflac struct {
-	Sources    []string `env:"SPOTIFLAC_SOURCES" env-default:"deezer,tidal,qobuz,amazon"`
+	Sources    []string `env:"SPOTIFLAC_SOURCES" env-default:"deezer,tidal,qobuz,amazon,netease,joox"`
 	Quality    string   `env:"SPOTIFLAC_QUALITY" env-default:"LOSSLESS"`
 	BinPath    string   `env:"SPOTIFLAC_BIN" env-default:"spotiflac"`
 	PythonPath string   `env:"SPOTIFLAC_PYTHON_PATH" env-default:"python3"`

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -99,6 +99,7 @@ type DownloadConfig struct {
 	Youtube           Youtube
 	YoutubeMusic      YoutubeMusic
 	Slskd             Slskd
+	Spotiflac         Spotiflac
 	ExcludeLocal      bool
 	DownloadLimiter   int    `env:"DOWNLOAD_LIMITER" env-default:"1"` // rate limit download operations
 	OverwriteMetadata bool   `env:"OVERWRITE_METADATA" env-default:"false"` // overwrite metadata when migrating downloads
@@ -132,6 +133,18 @@ type YoutubeMusic struct {
 	FfmpegPath string `env:"FFMPEG_PATH"`
 	YtdlpPath  string `env:"YTDLP_PATH"`
 	Filters    Filters
+}
+
+// Spotiflac configures the 'spotiflac' download service. Sources is the list of
+// FLAC providers to try in priority order; see sample.env for the full reference.
+type Spotiflac struct {
+	Sources        []string `env:"SPOTIFLAC_SOURCES" env-default:"deezer,tidal,qobuz,amazon"`
+	Quality        string   `env:"SPOTIFLAC_QUALITY" env-default:"LOSSLESS"`
+	PythonPath     string   `env:"SPOTIFLAC_PYTHON_PATH" env-default:"python3"`
+	ScriptPath     string   `env:"SPOTIFLAC_SCRIPT_PATH" env-default:"spotiflac_dl.py"`
+	Timeout        int      `env:"SPOTIFLAC_TIMEOUT" env-default:"180"`
+	FilenameFormat string   `env:"SPOTIFLAC_FILENAME_FORMAT" env-default:"{title} - {artist}"`
+	QobuzToken     string   `env:"SPOTIFLAC_QOBUZ_TOKEN"`
 }
 
 type Slskd struct {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -135,16 +135,20 @@ type YoutubeMusic struct {
 	Filters    Filters
 }
 
-// Spotiflac configures the 'spotiflac' download service. Sources is the list of
-// FLAC providers to try in priority order; see sample.env for the full reference.
+// Spotiflac configures the 'spotiflac' download service. It has two paths:
+// tracks that carry a streaming URL (e.g. Spotify imports) are downloaded via the
+// official SpotiFLAC CLI (BinPath); tracks matched by ISRC/title-artist (e.g.
+// ListenBrainz discovery) are downloaded via the bundled module helper
+// (PythonPath + ScriptPath). Sources is the list of FLAC providers to try in
+// priority order; see sample.env for the full reference.
 type Spotiflac struct {
-	Sources        []string `env:"SPOTIFLAC_SOURCES" env-default:"deezer,tidal,qobuz,amazon"`
-	Quality        string   `env:"SPOTIFLAC_QUALITY" env-default:"LOSSLESS"`
-	PythonPath     string   `env:"SPOTIFLAC_PYTHON_PATH" env-default:"python3"`
-	ScriptPath     string   `env:"SPOTIFLAC_SCRIPT_PATH" env-default:"spotiflac_dl.py"`
-	Timeout        int      `env:"SPOTIFLAC_TIMEOUT" env-default:"180"`
-	FilenameFormat string   `env:"SPOTIFLAC_FILENAME_FORMAT" env-default:"{title} - {artist}"`
-	QobuzToken     string   `env:"SPOTIFLAC_QOBUZ_TOKEN"`
+	Sources    []string `env:"SPOTIFLAC_SOURCES" env-default:"deezer,tidal,qobuz,amazon"`
+	Quality    string   `env:"SPOTIFLAC_QUALITY" env-default:"LOSSLESS"`
+	BinPath    string   `env:"SPOTIFLAC_BIN" env-default:"spotiflac"`
+	PythonPath string   `env:"SPOTIFLAC_PYTHON_PATH" env-default:"python3"`
+	ScriptPath string   `env:"SPOTIFLAC_SCRIPT_PATH" env-default:"spotiflac_dl.py"`
+	Timeout    int      `env:"SPOTIFLAC_TIMEOUT" env-default:"180"`
+	Retries    int      `env:"SPOTIFLAC_RETRIES" env-default:"2"`
 }
 
 type Slskd struct {

--- a/src/downloader/downloader.go
+++ b/src/downloader/downloader.go
@@ -44,6 +44,8 @@ func NewDownloader(cfg *cfg.DownloadConfig, httpClient *util.HttpClient, filterL
 			slskdClient := NewSlskd(cfg.Slskd, cfg.DownloadDir)
 			slskdClient.AddHeader()
 			downloader = append(downloader, slskdClient)
+		case "spotiflac":
+			downloader = append(downloader, NewSpotiflac(cfg.Spotiflac, cfg.DownloadDir))
 		default:
 			return nil, fmt.Errorf("downloader '%s' not supported", service)
 		}
@@ -120,7 +122,7 @@ func (c *DownloadClient) StartDownload(tracks *[]*models.Track) {
 }
 func (c *DownloadClient) needsDownloadDir() bool {
 	for _, svc := range c.Cfg.Services {
-		if svc == "youtube" || svc == "youtube-music" {
+		if svc == "youtube" || svc == "youtube-music" || svc == "spotiflac" {
 			return true
 		}
 	}

--- a/src/downloader/spotiflac.go
+++ b/src/downloader/spotiflac.go
@@ -34,7 +34,7 @@ const spotiflacMinBytes = 64 * 1024
 //     title/artist text-search fallback — mirroring how the youtube service shells
 //     out to ytmusicapi.
 //
-// Either way SpotiFLAC tries the configured sources (deezer, tidal, qobuz, amazon)
+// Either way SpotiFLAC tries the configured sources (deezer, tidal, qobuz, amazon, netease, joox)
 // in priority order. Tracks with neither a URL nor enough metadata are skipped so
 // the other configured services (slskd/youtube) can take over.
 type Spotiflac struct {

--- a/src/downloader/spotiflac.go
+++ b/src/downloader/spotiflac.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,11 +17,26 @@ import (
 	"explo/src/models"
 )
 
-// Spotiflac downloads lossless (FLAC) tracks by shelling out to the bundled
-// SpotiFLAC python wrapper (src/downloader/spotiflac/spotiflac_dl.py), mirroring
-// how the youtube service uses the ytmusicapi helper. SpotiFLAC resolves a track
-// by ISRC (falling back to a title/artist search) and downloads it from one of
-// several FLAC sources (deezer, tidal, qobuz, amazon) in priority order.
+// spotiflacMinBytes is the smallest file the CLI path treats as a successful
+// download. A real lossless (or even lossy fallback) track is multiple megabytes;
+// a partial/aborted download is far smaller, so this guards against half-written
+// files being reported as "present".
+const spotiflacMinBytes = 64 * 1024
+
+// Spotiflac downloads lossless (FLAC) tracks via SpotiFLAC
+// (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version), with two paths:
+//
+//   - Tracks that carry a streaming URL (e.g. Spotify-imported playlists) are
+//     downloaded with the official `spotiflac` CLI, which matches the exact track.
+//   - Tracks matched only by metadata (e.g. ListenBrainz discovery: ISRC or
+//     title/artist) are downloaded with the bundled module helper
+//     (spotiflac_dl.py), which searches each FLAC provider by ISRC with a
+//     title/artist text-search fallback — mirroring how the youtube service shells
+//     out to ytmusicapi.
+//
+// Either way SpotiFLAC tries the configured sources (deezer, tidal, qobuz, amazon)
+// in priority order. Tracks with neither a URL nor enough metadata are skipped so
+// the other configured services (slskd/youtube) can take over.
 type Spotiflac struct {
 	DownloadDir string
 	Cfg         cfg.Spotiflac
@@ -31,26 +49,23 @@ func NewSpotiflac(cfg cfg.Spotiflac, downloadDir string) *Spotiflac {
 	}
 }
 
-// spotiflacPayload is the JSON contract passed to the python wrapper.
+// spotiflacPayload is the JSON contract passed to the module helper.
 type spotiflacPayload struct {
-	ID             string   `json:"id"`
-	Title          string   `json:"title"`
-	Artists        string   `json:"artists"`
-	Album          string   `json:"album"`
-	AlbumArtist    string   `json:"album_artist"`
-	ISRC           string   `json:"isrc"`
-	TrackNumber    int      `json:"track_number"`
-	DurationMs     int      `json:"duration_ms"`
-	CoverURL       string   `json:"cover_url"`
-	OutputDir      string   `json:"output_dir"`
-	Sources        []string `json:"sources"`
-	Quality        string   `json:"quality,omitempty"`
-	FilenameFormat string   `json:"filename_format,omitempty"`
-	QobuzToken     string   `json:"qobuz_token,omitempty"`
-	TimeoutS       int      `json:"timeout_s,omitempty"`
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Artists     string   `json:"artists"`
+	Album       string   `json:"album"`
+	AlbumArtist string   `json:"album_artist"`
+	ISRC        string   `json:"isrc"`
+	TrackNumber int      `json:"track_number"`
+	DurationMs  int      `json:"duration_ms"`
+	CoverURL    string   `json:"cover_url"`
+	OutputDir   string   `json:"output_dir"`
+	Sources     []string `json:"sources"`
+	TimeoutS    int      `json:"timeout_s,omitempty"`
 }
 
-// spotiflacResult is the JSON the wrapper prints on stdout.
+// spotiflacResult is the JSON the module helper prints on stdout.
 type spotiflacResult struct {
 	Success  bool   `json:"success"`
 	File     string `json:"file"`
@@ -61,36 +76,125 @@ type spotiflacResult struct {
 }
 
 func (c *Spotiflac) QueryTrack(track *models.Track) error {
-	// SpotiFLAC resolves and downloads in a single step (GetTrack); here we only
-	// ensure the track carries enough to match on.
-	if firstISRC(track) == "" && (track.CleanTitle == "" || track.Artist == "") {
-		return fmt.Errorf("[spotiflac] insufficient metadata (need ISRC or title+artist) for '%s - %s'", track.Title, track.Artist)
+	// SpotiFLAC resolves and downloads in a single step (GetTrack). Accept the
+	// track if we have any usable handle on it; otherwise return an error so
+	// StartDownload skips it and the next configured service takes over.
+	if track.SourceURL != "" || firstISRC(track) != "" {
+		return nil
 	}
-	return nil
+	if (track.CleanTitle != "" || track.Title != "") && track.Artist != "" {
+		return nil
+	}
+	return fmt.Errorf("[spotiflac] insufficient metadata (need a streaming URL, ISRC, or title+artist) for '%s - %s'", track.Title, track.Artist)
 }
 
 func (c *Spotiflac) GetTrack(track *models.Track) error {
+	if track.SourceURL != "" {
+		return c.getViaCLI(track)
+	}
+	return c.getViaHelper(track)
+}
+
+// getViaCLI downloads a track that carries a streaming URL using the official
+// `spotiflac` CLI. The CLI emits no machine-readable result, so success is
+// determined by the deterministic -o output file, not the exit code.
+func (c *Spotiflac) getViaCLI(track *models.Track) error {
+	bin := c.Cfg.BinPath
+	if bin == "" {
+		bin = "spotiflac"
+	}
+
+	filename := getFilename(track.CleanTitle, track.MainArtist) + ".flac"
+	outPath := filepath.Join(c.DownloadDir, filename)
+
+	// Clear any stale file at the target path so the post-run existence check
+	// reliably reflects this download.
+	_ = os.Remove(outPath)
+
+	quality := c.Cfg.Quality
+	if quality == "" {
+		quality = "LOSSLESS"
+	}
+
+	args := []string{
+		track.SourceURL,
+		c.DownloadDir,
+		"-o", outPath,
+		"-q", quality,
+		"--retries", strconv.Itoa(c.Cfg.Retries),
+		// Skip lyrics + metadata enrichment: keeps batch downloads fast and
+		// deterministic. The music system handles richer metadata itself.
+		"--no-lyrics", "--no-enrich",
+	}
+	if c.Cfg.Timeout > 0 {
+		args = append(args, "--timeout", strconv.Itoa(c.Cfg.Timeout))
+	}
+	// --service takes a space-separated list (nargs='+'), so it must come last
+	// to avoid argparse swallowing the positional url/output_dir arguments.
+	if len(c.Cfg.Sources) > 0 {
+		args = append(args, "-s")
+		args = append(args, c.Cfg.Sources...)
+	}
+
+	ctx := context.Background()
+	if c.Cfg.Timeout > 0 {
+		// Generous outer ceiling so a wedged process can't hang a run: the
+		// per-track --timeout bounds each attempt; retries cycle all providers
+		// with backoff, so budget for (retries+1) attempts plus IO/metadata slack.
+		budget := c.Cfg.Timeout*(c.Cfg.Retries+1) + 120
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(budget)*time.Second)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	runErr := cmd.Run()
+
+	info, statErr := os.Stat(outPath)
+	if statErr != nil || info.Size() < spotiflacMinBytes {
+		detail := lastLine(stderr.String())
+		if detail == "" && runErr != nil {
+			detail = runErr.Error()
+		}
+		if detail == "" {
+			detail = "no file produced"
+		}
+		return fmt.Errorf("[spotiflac] no download for '%s - %s': %s", track.CleanTitle, track.Artist, detail)
+	}
+
+	track.File = filename
+	track.Present = true
+	slog.Info("download finished", "service", "spotiflac", "track", filename, "source", track.SourceURL)
+	return nil
+}
+
+// getViaHelper downloads a track matched only by metadata (ISRC or title/artist)
+// using the bundled SpotiFLAC module helper, which searches each provider.
+func (c *Spotiflac) getViaHelper(track *models.Track) error {
 	albumArtist := track.AlbumArtist
 	if albumArtist == "" {
 		albumArtist = track.MainArtist
 	}
+	title := track.CleanTitle
+	if title == "" {
+		title = track.Title
+	}
 
 	payload := spotiflacPayload{
-		ID:             track.MusicBrainzTrackID,
-		Title:          track.CleanTitle,
-		Artists:        track.Artist,
-		Album:          track.Album,
-		AlbumArtist:    albumArtist,
-		ISRC:           firstISRC(track),
-		TrackNumber:    track.TrackNumber,
-		DurationMs:     track.Duration,
-		CoverURL:       track.CoverURL,
-		OutputDir:      c.DownloadDir,
-		Sources:        c.Cfg.Sources,
-		Quality:        c.Cfg.Quality,
-		FilenameFormat: c.Cfg.FilenameFormat,
-		QobuzToken:     c.Cfg.QobuzToken,
-		TimeoutS:       c.Cfg.Timeout,
+		ID:          track.MusicBrainzTrackID,
+		Title:       title,
+		Artists:     track.Artist,
+		Album:       track.Album,
+		AlbumArtist: albumArtist,
+		ISRC:        firstISRC(track),
+		TrackNumber: track.TrackNumber,
+		DurationMs:  track.Duration,
+		CoverURL:    track.CoverURL,
+		OutputDir:   c.DownloadDir,
+		Sources:     c.Cfg.Sources,
+		TimeoutS:    c.Cfg.Timeout,
 	}
 
 	body, err := json.Marshal(payload)
@@ -100,7 +204,7 @@ func (c *Spotiflac) GetTrack(track *models.Track) error {
 
 	ctx := context.Background()
 	if c.Cfg.Timeout > 0 {
-		// Give the subprocess some slack over its own per-track timeout so it can
+		// Give the subprocess slack over its own per-track timeout so it can
 		// report a clean failure before the context kills it.
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(c.Cfg.Timeout+30)*time.Second)
@@ -111,7 +215,7 @@ func (c *Spotiflac) GetTrack(track *models.Track) error {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	stdout, runErr := cmd.Output() // wrapper exits non-zero on failure but still prints JSON
+	stdout, runErr := cmd.Output() // helper exits non-zero on failure but still prints JSON
 
 	result, parseErr := parseSpotiflacResult(stdout)
 	if parseErr != nil {
@@ -119,11 +223,11 @@ func (c *Spotiflac) GetTrack(track *models.Track) error {
 		if detail == "" && runErr != nil {
 			detail = runErr.Error()
 		}
-		return fmt.Errorf("[spotiflac] wrapper failed for '%s - %s': %s", track.CleanTitle, track.Artist, detail)
+		return fmt.Errorf("[spotiflac] helper failed for '%s - %s': %s", title, track.Artist, detail)
 	}
 
 	if !result.Success {
-		return fmt.Errorf("[spotiflac] no download for '%s - %s': %s", track.CleanTitle, track.Artist, result.Error)
+		return fmt.Errorf("[spotiflac] no download for '%s - %s': %s", title, track.Artist, result.Error)
 	}
 
 	track.File = result.File
@@ -152,7 +256,7 @@ func firstISRC(track *models.Track) string {
 	return ""
 }
 
-// parseSpotiflacResult reads the last JSON object printed on the wrapper's stdout.
+// parseSpotiflacResult reads the last JSON object printed on the helper's stdout.
 func parseSpotiflacResult(stdout []byte) (*spotiflacResult, error) {
 	line := lastJSONLine(string(stdout))
 	if line == "" {
@@ -160,7 +264,7 @@ func parseSpotiflacResult(stdout []byte) (*spotiflacResult, error) {
 	}
 	var res spotiflacResult
 	if err := json.Unmarshal([]byte(line), &res); err != nil {
-		return nil, fmt.Errorf("failed to parse wrapper output: %w", err)
+		return nil, fmt.Errorf("failed to parse helper output: %w", err)
 	}
 	return &res, nil
 }
@@ -175,6 +279,8 @@ func lastJSONLine(s string) string {
 	return ""
 }
 
+// lastLine returns the last non-empty line of s, used to surface a concise
+// failure reason from a subprocess's stderr.
 func lastLine(s string) string {
 	lines := strings.Split(strings.TrimSpace(s), "\n")
 	for i := len(lines) - 1; i >= 0; i-- {

--- a/src/downloader/spotiflac.go
+++ b/src/downloader/spotiflac.go
@@ -1,0 +1,186 @@
+package downloader
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+
+	cfg "explo/src/config"
+	"explo/src/models"
+)
+
+// Spotiflac downloads lossless (FLAC) tracks by shelling out to the bundled
+// SpotiFLAC python wrapper (src/downloader/spotiflac/spotiflac_dl.py), mirroring
+// how the youtube service uses the ytmusicapi helper. SpotiFLAC resolves a track
+// by ISRC (falling back to a title/artist search) and downloads it from one of
+// several FLAC sources (deezer, tidal, qobuz, amazon) in priority order.
+type Spotiflac struct {
+	DownloadDir string
+	Cfg         cfg.Spotiflac
+}
+
+func NewSpotiflac(cfg cfg.Spotiflac, downloadDir string) *Spotiflac {
+	return &Spotiflac{
+		DownloadDir: downloadDir,
+		Cfg:         cfg,
+	}
+}
+
+// spotiflacPayload is the JSON contract passed to the python wrapper.
+type spotiflacPayload struct {
+	ID             string   `json:"id"`
+	Title          string   `json:"title"`
+	Artists        string   `json:"artists"`
+	Album          string   `json:"album"`
+	AlbumArtist    string   `json:"album_artist"`
+	ISRC           string   `json:"isrc"`
+	TrackNumber    int      `json:"track_number"`
+	DurationMs     int      `json:"duration_ms"`
+	CoverURL       string   `json:"cover_url"`
+	OutputDir      string   `json:"output_dir"`
+	Sources        []string `json:"sources"`
+	Quality        string   `json:"quality,omitempty"`
+	FilenameFormat string   `json:"filename_format,omitempty"`
+	QobuzToken     string   `json:"qobuz_token,omitempty"`
+	TimeoutS       int      `json:"timeout_s,omitempty"`
+}
+
+// spotiflacResult is the JSON the wrapper prints on stdout.
+type spotiflacResult struct {
+	Success  bool   `json:"success"`
+	File     string `json:"file"`
+	Path     string `json:"path"`
+	Provider string `json:"provider"`
+	Format   string `json:"format"`
+	Error    string `json:"error"`
+}
+
+func (c *Spotiflac) QueryTrack(track *models.Track) error {
+	// SpotiFLAC resolves and downloads in a single step (GetTrack); here we only
+	// ensure the track carries enough to match on.
+	if firstISRC(track) == "" && (track.CleanTitle == "" || track.Artist == "") {
+		return fmt.Errorf("[spotiflac] insufficient metadata (need ISRC or title+artist) for '%s - %s'", track.Title, track.Artist)
+	}
+	return nil
+}
+
+func (c *Spotiflac) GetTrack(track *models.Track) error {
+	albumArtist := track.AlbumArtist
+	if albumArtist == "" {
+		albumArtist = track.MainArtist
+	}
+
+	payload := spotiflacPayload{
+		ID:             track.MusicBrainzTrackID,
+		Title:          track.CleanTitle,
+		Artists:        track.Artist,
+		Album:          track.Album,
+		AlbumArtist:    albumArtist,
+		ISRC:           firstISRC(track),
+		TrackNumber:    track.TrackNumber,
+		DurationMs:     track.Duration,
+		CoverURL:       track.CoverURL,
+		OutputDir:      c.DownloadDir,
+		Sources:        c.Cfg.Sources,
+		Quality:        c.Cfg.Quality,
+		FilenameFormat: c.Cfg.FilenameFormat,
+		QobuzToken:     c.Cfg.QobuzToken,
+		TimeoutS:       c.Cfg.Timeout,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal spotiflac payload: %w", err)
+	}
+
+	ctx := context.Background()
+	if c.Cfg.Timeout > 0 {
+		// Give the subprocess some slack over its own per-track timeout so it can
+		// report a clean failure before the context kills it.
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(c.Cfg.Timeout+30)*time.Second)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, c.Cfg.PythonPath, c.Cfg.ScriptPath, string(body))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	stdout, runErr := cmd.Output() // wrapper exits non-zero on failure but still prints JSON
+
+	result, parseErr := parseSpotiflacResult(stdout)
+	if parseErr != nil {
+		detail := lastLine(stderr.String())
+		if detail == "" && runErr != nil {
+			detail = runErr.Error()
+		}
+		return fmt.Errorf("[spotiflac] wrapper failed for '%s - %s': %s", track.CleanTitle, track.Artist, detail)
+	}
+
+	if !result.Success {
+		return fmt.Errorf("[spotiflac] no download for '%s - %s': %s", track.CleanTitle, track.Artist, result.Error)
+	}
+
+	track.File = result.File
+	track.Present = true
+	slog.Info("download finished", "service", "spotiflac", "track", result.File, "source", result.Provider)
+	return nil
+}
+
+// Monitor interface — SpotiFLAC downloads synchronously, there is no queue to poll.
+func (c *Spotiflac) GetConf() (MonitorConfig, error) {
+	return MonitorConfig{}, fmt.Errorf("[spotiflac] no monitoring required")
+}
+
+func (c *Spotiflac) GetDownloadStatus(tracks []*models.Track) (map[string]FileStatus, error) {
+	return nil, fmt.Errorf("[spotiflac] no monitoring required")
+}
+
+func (c *Spotiflac) Cleanup(track models.Track, ID string) error {
+	return nil
+}
+
+func firstISRC(track *models.Track) string {
+	if len(track.ISRCs) > 0 {
+		return track.ISRCs[0]
+	}
+	return ""
+}
+
+// parseSpotiflacResult reads the last JSON object printed on the wrapper's stdout.
+func parseSpotiflacResult(stdout []byte) (*spotiflacResult, error) {
+	line := lastJSONLine(string(stdout))
+	if line == "" {
+		return nil, fmt.Errorf("no JSON output")
+	}
+	var res spotiflacResult
+	if err := json.Unmarshal([]byte(line), &res); err != nil {
+		return nil, fmt.Errorf("failed to parse wrapper output: %w", err)
+	}
+	return &res, nil
+}
+
+func lastJSONLine(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if l := strings.TrimSpace(lines[i]); strings.HasPrefix(l, "{") {
+			return l
+		}
+	}
+	return ""
+}
+
+func lastLine(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if l := strings.TrimSpace(lines[i]); l != "" {
+			return l
+		}
+	}
+	return ""
+}

--- a/src/downloader/spotiflac/spotiflac_dl.py
+++ b/src/downloader/spotiflac/spotiflac_dl.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Bundled wrapper that downloads a single track via the SpotiFLAC module.
+
+Explo invokes this as a subprocess (mirroring how youtube_music/search_ytmusic.py
+shells out to ytmusicapi). It receives the track metadata as a JSON object on
+argv[1] (or stdin), tries each configured source/provider in priority order, and
+prints a single JSON result line to stdout:
+
+    {"success": true, "file": "Song.flac", "path": "/abs/Song.flac",
+     "provider": "deezer", "format": "flac"}
+
+or, on failure:
+
+    {"success": false, "error": "deezer: ...; tidal: ..."}
+
+All library/diagnostic output is routed to stderr so stdout carries only the
+final JSON line for the Go side to parse.
+"""
+import sys
+import os
+import json
+import contextlib
+
+
+def _read_payload():
+    if len(sys.argv) > 1 and sys.argv[1] not in ("-", ""):
+        return json.loads(sys.argv[1])
+    return json.loads(sys.stdin.read())
+
+
+def _run(p):
+    try:
+        from SpotiFLAC.providers import PROVIDER_REGISTRY
+        from SpotiFLAC.core.models import TrackMetadata
+    except Exception as e:  # noqa: BLE001 - report import failure to caller as JSON
+        return {"success": False, "error": f"SpotiFLAC import failed: {e}"}
+
+    meta = TrackMetadata(
+        id=str(p.get("id") or p.get("isrc") or "explo"),
+        title=p.get("title", ""),
+        artists=p.get("artists", ""),
+        album=p.get("album", ""),
+        album_artist=p.get("album_artist") or p.get("artists", ""),
+        isrc=p.get("isrc") or "",
+        track_number=int(p.get("track_number") or 0),
+        duration_ms=int(p.get("duration_ms") or 0),
+        cover_url=p.get("cover_url") or "",
+    )
+
+    output_dir = p["output_dir"]
+    os.makedirs(output_dir, exist_ok=True)
+
+    sources = p.get("sources") or ["deezer", "tidal", "qobuz", "amazon"]
+    quality = p.get("quality") or ""
+    filename_format = p.get("filename_format") or "{title} - {artist}"
+    qobuz_token = p.get("qobuz_token") or ""
+    timeout_s = int(p.get("timeout_s") or 0) or None
+
+    errors = []
+    for name in sources:
+        cls = PROVIDER_REGISTRY.get(name)
+        if cls is None:
+            errors.append(f"{name}: unknown source")
+            continue
+        try:
+            provider = cls(timeout_s=timeout_s) if timeout_s else cls()
+        except TypeError:
+            provider = cls()
+
+        kwargs = {"allow_fallback": True, "filename_format": filename_format}
+        if quality:
+            kwargs["quality"] = quality
+        if qobuz_token:
+            kwargs["qobuz_token"] = qobuz_token
+
+        try:
+            res = provider.download_track(meta, output_dir, **kwargs)
+        except Exception as e:  # noqa: BLE001 - a failing provider must not abort the chain
+            errors.append(f"{name}: {e}")
+            continue
+
+        if getattr(res, "success", False) and getattr(res, "file_path", None):
+            return {
+                "success": True,
+                "file": os.path.basename(res.file_path),
+                "path": res.file_path,
+                "provider": res.provider,
+                "format": getattr(res, "format", None) or "flac",
+            }
+        errors.append(f"{name}: {getattr(res, 'error', None) or 'no file downloaded'}")
+
+    return {"success": False, "error": "; ".join(errors) or "all sources failed"}
+
+
+def main():
+    try:
+        payload = _read_payload()
+    except Exception as e:  # noqa: BLE001
+        print(json.dumps({"success": False, "error": f"invalid payload: {e}"}))
+        return 1
+
+    # Keep stdout clean: library prints/progress and logging go to stderr; only
+    # the final JSON (printed below, outside this block) reaches stdout.
+    with contextlib.redirect_stdout(sys.stderr):
+        outcome = _run(payload)
+
+    print(json.dumps(outcome))
+    return 0 if outcome.get("success") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/downloader/spotiflac/spotiflac_dl.py
+++ b/src/downloader/spotiflac/spotiflac_dl.py
@@ -58,7 +58,7 @@ def _run(p):
     output_dir = p["output_dir"]
     os.makedirs(output_dir, exist_ok=True)
 
-    sources = p.get("sources") or ["deezer", "tidal", "qobuz", "amazon"]
+    sources = p.get("sources") or ["deezer", "tidal", "qobuz", "amazon", "netease", "joox"]
     filename_format = p.get("filename_format") or "{title} - {artist}"
     timeout_s = int(p.get("timeout_s") or 0) or None
 

--- a/src/downloader/spotiflac/spotiflac_dl.py
+++ b/src/downloader/spotiflac/spotiflac_dl.py
@@ -19,6 +19,7 @@ final JSON line for the Go side to parse.
 import sys
 import os
 import json
+import asyncio
 import contextlib
 
 
@@ -74,7 +75,14 @@ def _run(p):
             kwargs["qobuz_token"] = qobuz_token
 
         try:
-            res = provider.download_track(meta, output_dir, **kwargs)
+            # download_track (<=1.2.0) became the async download_track_async (>=1.2.1)
+            if hasattr(provider, "download_track"):
+                res = provider.download_track(meta, output_dir, **kwargs)
+            elif hasattr(provider, "download_track_async"):
+                res = asyncio.run(provider.download_track_async(meta, output_dir, **kwargs))
+            else:
+                errors.append(f"{name}: provider exposes no download method")
+                continue
         except Exception as e:  # noqa: BLE001 - a failing provider must not abort the chain
             errors.append(f"{name}: {e}")
             continue

--- a/src/downloader/spotiflac/spotiflac_dl.py
+++ b/src/downloader/spotiflac/spotiflac_dl.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-"""Bundled wrapper that downloads a single track via the SpotiFLAC module.
+"""Bundled helper that downloads a single track via the SpotiFLAC module's
+provider API, used by Explo's spotiflac downloader for tracks that have no
+streaming URL (e.g. ListenBrainz discovery).
 
-Explo invokes this as a subprocess (mirroring how youtube_music/search_ytmusic.py
-shells out to ytmusicapi). It receives the track metadata as a JSON object on
-argv[1] (or stdin), tries each configured source/provider in priority order, and
-prints a single JSON result line to stdout:
+This mirrors how youtube_music/search_ytmusic.py shells out to ytmusicapi: it
+resolves a track by ISRC (falling back to a title/artist text search inside each
+provider) and downloads it from one of the configured FLAC sources in priority
+order. The official `spotiflac` CLI handles URL-based imports (e.g. Spotify); this
+helper handles the metadata-search path the CLI cannot do.
+
+It receives the track metadata as a JSON object on argv[1] (or stdin) and prints a
+single JSON result line to stdout:
 
     {"success": true, "file": "Song.flac", "path": "/abs/Song.flac",
      "provider": "deezer", "format": "flac"}
@@ -36,12 +42,13 @@ def _run(p):
     except Exception as e:  # noqa: BLE001 - report import failure to caller as JSON
         return {"success": False, "error": f"SpotiFLAC import failed: {e}"}
 
+    artists = p.get("artists") or ""
     meta = TrackMetadata(
         id=str(p.get("id") or p.get("isrc") or "explo"),
         title=p.get("title", ""),
-        artists=p.get("artists", ""),
-        album=p.get("album", ""),
-        album_artist=p.get("album_artist") or p.get("artists", ""),
+        artists=artists,
+        album=p.get("album") or "",
+        album_artist=p.get("album_artist") or artists,
         isrc=p.get("isrc") or "",
         track_number=int(p.get("track_number") or 0),
         duration_ms=int(p.get("duration_ms") or 0),
@@ -52,9 +59,7 @@ def _run(p):
     os.makedirs(output_dir, exist_ok=True)
 
     sources = p.get("sources") or ["deezer", "tidal", "qobuz", "amazon"]
-    quality = p.get("quality") or ""
     filename_format = p.get("filename_format") or "{title} - {artist}"
-    qobuz_token = p.get("qobuz_token") or ""
     timeout_s = int(p.get("timeout_s") or 0) or None
 
     errors = []
@@ -68,21 +73,18 @@ def _run(p):
         except TypeError:
             provider = cls()
 
-        kwargs = {"allow_fallback": True, "filename_format": filename_format}
-        if quality:
-            kwargs["quality"] = quality
-        if qobuz_token:
-            kwargs["qobuz_token"] = qobuz_token
-
         try:
-            # download_track (<=1.2.0) became the async download_track_async (>=1.2.1)
-            if hasattr(provider, "download_track"):
-                res = provider.download_track(meta, output_dir, **kwargs)
-            elif hasattr(provider, "download_track_async"):
-                res = asyncio.run(provider.download_track_async(meta, output_dir, **kwargs))
-            else:
-                errors.append(f"{name}: provider exposes no download method")
-                continue
+            # Each provider matches by ISRC first, then a title/artist text search.
+            # allow_fallback=False keeps this provider self-contained so our own
+            # source loop controls the priority order.
+            res = asyncio.run(
+                provider.download_track_async(
+                    meta,
+                    output_dir,
+                    filename_format=filename_format,
+                    allow_fallback=False,
+                )
+            )
         except Exception as e:  # noqa: BLE001 - a failing provider must not abort the chain
             errors.append(f"{name}: {e}")
             continue

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -35,6 +35,7 @@ func loadCustomTracks(dataDir, playlistID string) ([]*models.Track, string, erro
 		Release    string `json:"release"`
 		CoverURL   string `json:"coverUrl"`
 		CoverPath  string `json:"coverPath"`
+		SourceURL  string `json:"sourceUrl"`
 	}
 	type cacheFile struct {
 		Tracks []cachedTrack `json:"tracks"`
@@ -81,6 +82,7 @@ func loadCustomTracks(dataDir, playlistID string) ([]*models.Track, string, erro
 			Album:      t.Release,
 			CoverURL:   t.CoverURL,
 			CoverPath:  t.CoverPath,
+			SourceURL:  t.SourceURL,
 		}
 	}
 	return tracks, name, nil

--- a/src/models/types.go
+++ b/src/models/types.go
@@ -26,6 +26,7 @@ type Track struct {
 	OriginalYear              int
 	Genres                    string
 	ISRCs                     []string
+	SourceURL                 string // Streaming URL (e.g. Spotify track link) captured from a URL-based import; used by the spotiflac downloader
 	Media                     string // Media format (e.g., CD, Digital Media)
 	TrackNumber               int    // Track position in media
 	TrackTotal                int    // Total tracks in media

--- a/src/web/backend/playlists.go
+++ b/src/web/backend/playlists.go
@@ -30,6 +30,7 @@ type PlaylistTrack struct {
 	MainArtist string
 	Album      string
 	CoverURL   string
+	SourceURL  string // streaming URL (e.g. Spotify track link); empty for sources without per-track URLs
 }
 
 // validPlaylistTypes is derived from playlistDefs — no manual sync needed.
@@ -235,6 +236,7 @@ type cachedPrefetchTrack struct {
 	Release    string `json:"release"`
 	CoverURL   string `json:"coverUrl,omitempty"`
 	CoverPath  string `json:"coverPath,omitempty"`
+	SourceURL  string `json:"sourceUrl,omitempty"`
 }
 
 // writePreliminaryCache writes the track cache with remote cover URLs immediately.
@@ -242,7 +244,7 @@ type cachedPrefetchTrack struct {
 func writePreliminaryCache(cfgDir, playlistType string, tracks []PlaylistTrack) bool {
 	ct := make([]cachedPrefetchTrack, len(tracks))
 	for i, t := range tracks {
-		ct[i] = cachedPrefetchTrack{Rank: i + 1, Title: t.Title, Artist: t.Artist, MainArtist: t.MainArtist, Release: t.Album, CoverURL: t.CoverURL}
+		ct[i] = cachedPrefetchTrack{Rank: i + 1, Title: t.Title, Artist: t.Artist, MainArtist: t.MainArtist, Release: t.Album, CoverURL: t.CoverURL, SourceURL: t.SourceURL}
 	}
 	if !writeTrackCache(cfgDir, playlistType, ct) {
 		return false
@@ -262,7 +264,7 @@ func downloadAndCacheCovers(cfgDir, playlistType string, tracks []PlaylistTrack)
 	ct := make([]cachedPrefetchTrack, len(tracks))
 	for i, t := range tracks {
 		APIPath, coverPath := util.DownloadCover(t.CoverURL, coversDir)
-		ct[i] = cachedPrefetchTrack{Rank: i + 1, Title: t.Title, Artist: t.Artist, MainArtist: t.MainArtist, Release: t.Album, CoverURL: APIPath, CoverPath: coverPath}
+		ct[i] = cachedPrefetchTrack{Rank: i + 1, Title: t.Title, Artist: t.Artist, MainArtist: t.MainArtist, Release: t.Album, CoverURL: APIPath, CoverPath: coverPath, SourceURL: t.SourceURL}
 	}
 	if writeTrackCache(cfgDir, playlistType, ct) {
 		slog.Info("prefetch: cache updated", "playlist", playlistType, "covers", "local")

--- a/src/web/backend/spotify.go
+++ b/src/web/backend/spotify.go
@@ -540,6 +540,7 @@ type partnerItem struct {
 
 type partnerTrackData struct {
 	Typename string `json:"__typename"`
+	URI      string `json:"uri"` // e.g. "spotify:track:<id>" — used to build a track URL for SpotiFLAC
 	Name     string `json:"name"`
 	Artists  struct {
 		Items []struct {
@@ -706,9 +707,22 @@ func extractTracks(items []partnerItem) []PlaylistTrack {
 			MainArtist: mainArtist,
 			Album:      t.AlbumOfTrack.Name,
 			CoverURL:   coverURL,
+			SourceURL:  spotifyTrackURL(t.URI),
 		})
 	}
 	return tracks
+}
+
+// spotifyTrackURL converts a Spotify track URI ("spotify:track:<id>") into an
+// open.spotify.com track URL, which the SpotiFLAC CLI accepts as input.
+// Returns "" for anything that isn't a track URI (e.g. local/episode items).
+func spotifyTrackURL(uri string) string {
+	const prefix = "spotify:track:"
+	id := strings.TrimPrefix(uri, prefix)
+	if id == uri || id == "" {
+		return ""
+	}
+	return "https://open.spotify.com/track/" + id
 }
 
 // pickBestSource returns the image URL closest to targetSize pixels.

--- a/src/web/sample.env
+++ b/src/web/sample.env
@@ -105,15 +105,17 @@ LIBRARY_NAME=
 # === SpotiFLAC Configuration ===
 
 # Downloads lossless FLAC via SpotiFLAC (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version),
-# bundled in the docker image (pip install "SpotiFLAC>=1.2.3") with ffmpeg in $PATH.
-# To build the image with a different version: --build-arg SPOTIFLAC_VERSION=<version>
+# bundled in the docker image (the Dockerfile always installs the LATEST SpotiFLAC, since its
+# reverse-engineered backends break often and are fixed upstream) with ffmpeg in $PATH.
 # Add 'spotiflac' to DOWNLOAD_SERVICES to enable it. Tracks with a streaming URL
 # (Spotify-imported playlists) use the official `spotiflac` CLI; tracks matched by
 # ISRC/title-artist (e.g. ListenBrainz discovery) use the bundled module helper.
 # Tracks SpotiFLAC can't source fall through to the other configured services.
 
-# FLAC sources to try, in priority order (default: deezer,tidal,qobuz,amazon)
-# SPOTIFLAC_SOURCES=deezer,tidal,qobuz,amazon
+# FLAC sources to try, in priority order (default: deezer,tidal,qobuz,amazon,netease,joox).
+# Supported: deezer, tidal, qobuz, amazon, netease, joox, apple, kuwo, migu, pandora
+# (netease & joox are credential-free and cover many tracks the Western services miss).
+# SPOTIFLAC_SOURCES=deezer,tidal,qobuz,amazon,netease,joox
 # Preferred quality for the CLI path (default: LOSSLESS; e.g. HI_RES_LOSSLESS, LOSSLESS, HIGH)
 # SPOTIFLAC_QUALITY=LOSSLESS
 # Path to the spotiflac CLI (default: spotiflac, resolved from $PATH)

--- a/src/web/sample.env
+++ b/src/web/sample.env
@@ -104,25 +104,28 @@ LIBRARY_NAME=
 
 # === SpotiFLAC Configuration ===
 
-# Downloads lossless FLAC via the SpotiFLAC python module (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version).
-# Requires python3 with the SpotiFLAC module (>=1.2.1) installed (bundled in the docker image) and ffmpeg in $PATH.
-# To build the image with a different module version: --build-arg SPOTIFLAC_VERSION=<version>
-# Add 'spotiflac' to DOWNLOAD_SERVICES to enable it.
+# Downloads lossless FLAC via SpotiFLAC (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version),
+# bundled in the docker image (pip install "SpotiFLAC>=1.2.3") with ffmpeg in $PATH.
+# To build the image with a different version: --build-arg SPOTIFLAC_VERSION=<version>
+# Add 'spotiflac' to DOWNLOAD_SERVICES to enable it. Tracks with a streaming URL
+# (Spotify-imported playlists) use the official `spotiflac` CLI; tracks matched by
+# ISRC/title-artist (e.g. ListenBrainz discovery) use the bundled module helper.
+# Tracks SpotiFLAC can't source fall through to the other configured services.
 
 # FLAC sources to try, in priority order (default: deezer,tidal,qobuz,amazon)
 # SPOTIFLAC_SOURCES=deezer,tidal,qobuz,amazon
-# Preferred quality passed to the source (leave empty to use the provider's lossless default)
+# Preferred quality for the CLI path (default: LOSSLESS; e.g. HI_RES_LOSSLESS, LOSSLESS, HIGH)
 # SPOTIFLAC_QUALITY=LOSSLESS
-# Python interpreter that has the SpotiFLAC module installed (default: python3)
+# Path to the spotiflac CLI (default: spotiflac, resolved from $PATH)
+# SPOTIFLAC_BIN=spotiflac
+# Python interpreter with the SpotiFLAC module installed, for the helper path (default: python3)
 # SPOTIFLAC_PYTHON_PATH=python3
-# Path to the bundled wrapper script (default: spotiflac_dl.py; set to an absolute path for the binary version)
+# Path to the bundled module helper (default: spotiflac_dl.py; set an absolute path for the binary version)
 # SPOTIFLAC_SCRIPT_PATH=spotiflac_dl.py
 # Max seconds to spend downloading a single track before giving up (default: 180)
 # SPOTIFLAC_TIMEOUT=180
-# Filename format used by SpotiFLAC (default: {title} - {artist})
-# SPOTIFLAC_FILENAME_FORMAT={title} - {artist}
-# Optional Qobuz auth token passthrough
-# SPOTIFLAC_QOBUZ_TOKEN=
+# Extra download attempts per track on failure, cycling all sources (default: 2)
+# SPOTIFLAC_RETRIES=2
 
 # === Metadata / Formatting ===
 

--- a/src/web/sample.env
+++ b/src/web/sample.env
@@ -105,7 +105,8 @@ LIBRARY_NAME=
 # === SpotiFLAC Configuration ===
 
 # Downloads lossless FLAC via the SpotiFLAC python module (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version).
-# Requires python3 with the SpotiFLAC module installed (bundled in the docker image) and ffmpeg in $PATH.
+# Requires python3 with the SpotiFLAC module (>=1.2.1) installed (bundled in the docker image) and ffmpeg in $PATH.
+# To build the image with a different module version: --build-arg SPOTIFLAC_VERSION=<version>
 # Add 'spotiflac' to DOWNLOAD_SERVICES to enable it.
 
 # FLAC sources to try, in priority order (default: deezer,tidal,qobuz,amazon)

--- a/src/web/sample.env
+++ b/src/web/sample.env
@@ -48,6 +48,7 @@ LIBRARY_NAME=
 # Keep original file permissions when moving files (set to false on Synology devices)
 # KEEP_PERMISSIONS=true
 # Comma-separated list (no spaces) of download services, in priority order (default: youtube)
+# Supported: youtube, slskd, spotiflac
 # DOWNLOAD_SERVICES=youtube
 # Path templating, Options are Artist, Album, TrackName, TrackNumber, File, Ext (eg. "{{Artist}}/{{Album}}/{{File}}")
 # PATH_TEMPLATING=""
@@ -100,6 +101,27 @@ LIBRARY_NAME=
 # MIN_BITRATE=256
 # Comma-separated (without spaces) keywords to avoid, when filtering slskd results (default: live,remix,instrumental,extended,clean,acapella)
 # FILTER_LIST=live,remix,instrumental,extended,clean,acapella
+
+# === SpotiFLAC Configuration ===
+
+# Downloads lossless FLAC via the SpotiFLAC python module (https://github.com/ShuShuzinhuu/SpotiFLAC-Module-Version).
+# Requires python3 with the SpotiFLAC module installed (bundled in the docker image) and ffmpeg in $PATH.
+# Add 'spotiflac' to DOWNLOAD_SERVICES to enable it.
+
+# FLAC sources to try, in priority order (default: deezer,tidal,qobuz,amazon)
+# SPOTIFLAC_SOURCES=deezer,tidal,qobuz,amazon
+# Preferred quality passed to the source (leave empty to use the provider's lossless default)
+# SPOTIFLAC_QUALITY=LOSSLESS
+# Python interpreter that has the SpotiFLAC module installed (default: python3)
+# SPOTIFLAC_PYTHON_PATH=python3
+# Path to the bundled wrapper script (default: spotiflac_dl.py; set to an absolute path for the binary version)
+# SPOTIFLAC_SCRIPT_PATH=spotiflac_dl.py
+# Max seconds to spend downloading a single track before giving up (default: 180)
+# SPOTIFLAC_TIMEOUT=180
+# Filename format used by SpotiFLAC (default: {title} - {artist})
+# SPOTIFLAC_FILENAME_FORMAT={title} - {artist}
+# Optional Qobuz auth token passthrough
+# SPOTIFLAC_QOBUZ_TOKEN=
 
 # === Metadata / Formatting ===
 


### PR DESCRIPTION
Adds a `spotiflac` download service for pulling tracks as lossless FLAC.

Depending on what info Explo has for a track, it uses one of two paths:

- Spotify-imported playlists already have a track URL, so those go straight through the official `spotiflac` CLI.
- Everything else (ListenBrainz discovery, etc.) is looked up by ISRC, with a title/artist search fallback, using a small bundled python helper. Same idea as the existing youtube/ytmusicapi helper.

Both try the configured providers in order (deezer, tidal, qobuz, amazon). Anything that can't be found is skipped, so the other services in `DOWNLOAD_SERVICES` still get a turn.

To capture the URL for the first path, the Spotify import now reads each track's link from the partner API and carries it through to the downloader.

Config is documented in `sample.env`: `SPOTIFLAC_SOURCES`, `SPOTIFLAC_QUALITY`, `SPOTIFLAC_BIN`, `SPOTIFLAC_PYTHON_PATH`, `SPOTIFLAC_SCRIPT_PATH`, `SPOTIFLAC_TIMEOUT`, `SPOTIFLAC_RETRIES`. The docker image installs SpotiFLAC from PyPI (which gives both the CLI and the importable module) and copies in the helper script.

Tested locally with mpd: downloaded FLACs through both paths and checked they decode cleanly with ffmpeg.


### Tested with Spotify Playlist imported via Explo

I'm into very obscure music and I KNOW I'M GONNA HATE FOR THIS BUT I LIKE SOME OF THE AI MUSIC especially RnB and spotify's algorithm prioritizing AI artists is getting to me so I want FLAC files. Most of the FLACs I get are from Deezer

<img width="1530" height="1277" alt="image" src="https://github.com/user-attachments/assets/21de69dc-0f3f-4778-ab55-0139327b2f12" />

<img width="1102" height="1247" alt="image" src="https://github.com/user-attachments/assets/912bb763-2a6e-4db1-a007-e0159972362e" />


<img width="734" height="1137" alt="image" src="https://github.com/user-attachments/assets/e60d5e87-b579-4a47-827c-4948ba0ae385" />

Example logs from Explo when pulling the FLAC file from SpotiFLAC

```
time=2026-06-26T03:37:12.272+08:00 level=INFO msg="Starting Explo..."
time=2026-06-26T03:37:12.272+08:00 level=INFO msg="Pulling playlist" playlist=custom-ca2ae93d
time=2026-06-26T03:37:12.274+08:00 level=INFO msg="Saved playlist" playlist=custom-ca2ae93d tracks=30
time=2026-06-26T03:37:32.998+08:00 level=INFO msg="download finished" service=spotiflac track="UP DOWN - Dyce.flac" source=deezer
time=2026-06-26T03:37:47.277+08:00 level=INFO msg="download finished" service=spotiflac track="Champagne - Pitched Up Edit - Nic Dean.flac" source=deezer
time=2026-06-26T03:37:54.695+08:00 level=INFO msg="download finished" service=spotiflac track="Don't Rush - Slowed - Jakk Rinse.flac" source=deezer
time=2026-06-26T03:38:19.966+08:00 level=INFO msg="download finished" service=spotiflac track="I am in love - Jagganant George.flac" source=deezer
time=2026-06-26T03:38:22.022+08:00 level=INFO msg="download finished" service=spotiflac track="Chasing You - drill clinton.flac" source=qobuz
time=2026-06-26T03:38:44.967+08:00 level=INFO msg="download finished" service=spotiflac track="Outside - Daniel J.flac" source=qobuz
time=2026-06-26T03:38:55.112+08:00 level=INFO msg="download finished" service=spotiflac track="Officially Missing You - AYA MUSIC.flac" source=deezer
time=2026-06-26T03:39:09.302+08:00 level=INFO msg="download finished" service=spotiflac track="Only One I See - Iamkritical.flac" source=qobuz
time=2026-06-26T03:39:26.265+08:00 level=WARN msg="[spotiflac] no download for 'Can’t Stop the Feelin’ - Storch Blaize, Rico': deezer: No matching track on Deezer (ISRC lookup and text search both failed).; tidal: [tidal] TRACK_NOT_FOUND: Track not found for: explo; qobuz: [qobuz] UNAVAILABLE: All stream APIs failed; amazon: Unexpected: Could not resolve Amazon URL for explo via any method."
time=2026-06-26T03:39:28.351+08:00 level=INFO msg="download finished" service=spotiflac track="Don't Rush - Rocky Bowman.flac" source=qobuz
time=2026-06-26T03:39:35.077+08:00 level=INFO msg="download finished" service=spotiflac track="Emotionally Unavailable - Niykee Heaton.flac" source=deezer
time=2026-06-26T03:39:50.669+08:00 level=INFO msg="download finished" service=spotiflac track="Narcissist - Jon Blankenship.flac" source=deezer
time=2026-06-26T03:40:01.963+08:00 level=INFO msg="download finished" service=spotiflac track="DO WHAT I LIKE - DO WHAT I WANT, Russ Coson, Darrell Medellin, Kiyomi.flac" source=deezer
time=2026-06-26T03:40:07.183+08:00 level=WARN msg="[spotiflac] no download for 'When You Loved Too Hard - D'PRABU': deezer: No matching track on Deezer (ISRC lookup and text search both failed).; tidal: [tidal] TRACK_NOT_FOUND: Track not found for: explo; qobuz: [qobuz] UNAVAILABLE: All stream APIs failed; amazon: Unexpected: Could not resolve Amazon URL for explo via any method."
time=2026-06-26T03:40:19.179+08:00 level=INFO msg="download finished" service=spotiflac track="Go All In - Deanz, Revel Day.flac" source=deezer
time=2026-06-26T03:40:24.520+08:00 level=INFO msg="download finished" service=spotiflac track="Can't Lie - Jade Omari.flac" source=deezer
time=2026-06-26T03:40:54.757+08:00 level=INFO msg="download finished" service=spotiflac track="Everything You Do Is Amazing - D'JASMINE.flac" source=qobuz
time=2026-06-26T03:41:01.045+08:00 level=INFO msg="download finished" service=spotiflac track="Let You Go - Oh well..flac" source=qobuz
time=2026-06-26T03:41:01.715+08:00 level=INFO msg="download finished" service=spotiflac track="Eko - Jae.T.flac" source=qobuz
time=2026-06-26T03:41:18.861+08:00 level=INFO msg="download finished" service=spotiflac track="All That Matters - J.Tajor.flac" source=qobuz
time=2026-06-26T03:41:29.993+08:00 level=INFO msg="download finished" service=spotiflac track="1 In A Million - CALLMEJB.flac" source=qobuz
time=2026-06-26T03:41:35.012+08:00 level=INFO msg="download finished" service=spotiflac track="Hit Eazy - Eric Bellinger, Hitmaka.flac" source=qobuz
time=2026-06-26T03:41:52.870+08:00 level=INFO msg="download finished" service=spotiflac track="LIFELINE - Kodi Williams.flac" source=qobuz
time=2026-06-26T03:42:01.038+08:00 level=INFO msg="download finished" service=spotiflac track="Red Thread (Amo Lead) - Aston Aizen.flac" source=qobuz
time=2026-06-26T03:42:01.639+08:00 level=INFO msg="download finished" service=spotiflac track="don't stop - rl.flac" source=qobuz
time=2026-06-26T03:42:20.321+08:00 level=INFO msg="download finished" service=spotiflac track="Taste - Dylan Wild, Chris Taylor.flac" source=qobuz
time=2026-06-26T03:42:25.984+08:00 level=INFO msg="download finished" service=spotiflac track="Handle Me - Renn Olympus.flac" source=qobuz
time=2026-06-26T03:42:28.652+08:00 level=WARN msg="[spotiflac] no download for 'The Guest - Roman Noir': deezer: No matching track on Deezer (ISRC lookup and text search both failed).; tidal: [tidal] TRACK_NOT_FOUND: Track not found for: explo; qobuz: [qobuz] UNAVAILABLE: All stream APIs failed; amazon: Unexpected: Could not resolve Amazon URL for explo via any method."
time=2026-06-26T03:42:56.507+08:00 level=INFO msg="download finished" service=spotiflac track="Stay With Me - JAMO.flac" source=qobuz
time=2026-06-26T03:43:00.358+08:00 level=INFO msg="download finished" service=spotiflac track="closure - Paige Corwin.flac" source=qobuz
time=2026-06-26T03:43:00.358+08:00 level=WARN msg="[spotiflac] no monitoring required"
time=2026-06-26T03:43:00.442+08:00 level=INFO msg="initiating search" track="The Guest - Roman Noir"
time=2026-06-26T03:43:01.361+08:00 level=INFO msg="initiating search" track="Can’t Stop the Feelin’ - Storch Blaize, Rico"
time=2026-06-26T03:43:02.361+08:00 level=INFO msg="initiating search" track="When You Loved Too Hard - D'PRABU"
time=2026-06-26T03:43:15.485+08:00 level=INFO msg="initiating search" track="The Guest - *oman Noir"
time=2026-06-26T03:43:16.366+08:00 level=INFO msg="initiating search" track="Can’t Stop the Feelin’ - *torch Blaize, Rico"
time=2026-06-26T03:43:32.367+08:00 level=INFO msg="initiating search" track="When You Loved Too Hard - *'PRABU"
time=2026-06-26T03:43:45.501+08:00 level=WARN msg="no results found for query"
time=2026-06-26T03:43:46.370+08:00 level=WARN msg="no results found for query"
time=2026-06-26T03:43:47.369+08:00 level=WARN msg="no results found for query"
time=2026-06-26T03:44:47.377+08:00 level=WARN msg="[slskd/monitor] error fetching download status: no files found to monitor"
time=2026-06-26T03:44:55.283+08:00 level=INFO msg="compiled command: ffmpeg -i /data/Custom-Ca2ae93d/The_Guest-Roman_Noir.m4a.tmp -loglevel error -map 0:a -metadata artist=Roman Noir -metadata title=The Guest -metadata album=The Guest /data/Custom-Ca2ae93d/Roman Noir/The Guest/The Guest.m4a -y"
time=2026-06-26T03:44:55.452+08:00 level=INFO msg="download finished" service=youtube track=The_Guest-Roman_Noir.m4a
time=2026-06-26T03:44:56.379+08:00 level=INFO msg="compiled command: ffmpeg -i /data/Custom-Ca2ae93d/When_You_Loved_Too_Hard-D_PRABU.m4a.tmp -loglevel error -map 0:a -metadata artist=D'PRABU -metadata title=When You Loved Too Hard -metadata album=When You Loved Too Hard /data/Custom-Ca2ae93d/D'PRABU/When You Loved Too Hard/When You Loved Too Hard.m4a -y"
time=2026-06-26T03:44:56.498+08:00 level=INFO msg="download finished" service=youtube track=When_You_Loved_Too_Hard-D_PRABU.m4a
time=2026-06-26T03:44:57.274+08:00 level=INFO msg="compiled command: ffmpeg -i /data/Custom-Ca2ae93d/Can_t_Stop_the_Feelin_-Storch_Blaize,_Rico.m4a.tmp -loglevel error -map 0:a -metadata artist=Storch Blaize, Rico -metadata title=Can’t Stop the Feelin’ -metadata album=After Di Drinks /data/Custom-Ca2ae93d/Storch Blaize/After Di Drinks/Can’t Stop the Feelin’.m4a -y"
time=2026-06-26T03:44:57.389+08:00 level=INFO msg="download finished" service=youtube track=Can_t_Stop_the_Feelin_-Storch_Blaize,_Rico.m4a
time=2026-06-26T03:44:57.389+08:00 level=WARN msg="[youtube] no monitoring required"
time=2026-06-26T03:44:57.448+08:00 level=INFO msg="Refreshing library..." system=subsonic
time=2026-06-26T03:45:27.671+08:00 level=INFO msg="notification sent"
time=2026-06-26T03:45:27.671+08:00 level=INFO msg="playlist created successfully" system=subsonic playlistName="Discover Weekly" notify=true
time=2026-06-26T04:22:25.615+08:00 level=ERROR msg="Failed to read session from store" msg="session not found"
time=2026-06-26T04:29:40.550+08:00 level=INFO msg="successful login" user=pacholoamit
```


Refs #117
