### PR TITLE
Fix playlist toggle breaking when reloading page

### DIFF
--- a/src/web/backend/server.go
+++ b/src/web/backend/server.go
@@ -596,6 +596,15 @@ func (s *Server) handleSaveSchedule(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	for k, v := range updates {
+		if v == "" {
+			os.Unsetenv(k)
+		} else {
+			os.Setenv(k, v)
+		}
+	}
+
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
Fixes #187

When Explo starts, cleanenv loads all .env values into OS process memory via os.Setenv. If a playlist schedule exists in .env at startup, it lives in both the file and process memory.

When you toggle a schedule off, handleSaveSchedule removes the key from .env but never calls os.Unsetenv, so the stale value stays in memory. On the next page load, handleGetConfig checks the file first then falls back to os.LookupEnv, finds the stale value, and marks it source: "env". The frontend sees "env" as externally controlled and locks the toggle, showing the ENV text and an error cursor. Restarting the container clears process memory which is why the bug doesn't survive restarts.

The fix:
Added os.Unsetenv / os.Setenv in handleSaveSchedule after updateEnvKeys writes to the disk, keeping OS process memory in sync with the file on each toggle.