### PR TITLE
Improving track match rate in Jellyfin

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+name: Build and push image
+
+on:
+  push:
+    branches: [dev, main, master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/gtkashi/explogtk:latest
+          build-args: VERSION=fork

--- a/docker.yml
+++ b/docker.yml
@@ -1,0 +1,34 @@
+name: Build and push image
+
+on:
+  push:
+    branches: [dev, main, master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/gtkashi/explogtk:latest
+          build-args: VERSION=fork

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -167,17 +167,17 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 		if err = util.ParseResp(body, &results); err != nil {
 			return err
 		}
-		// 2. Precise Word-Isolation Fallback: If primary search returns 0 results, 
-		// fetch using just the first complete word of the song title to avoid index truncation.
+
+		// 2. Safe Fallback: If primary search returns 0 results, 
+		// search using just the first complete word of the song title.
 		if len(results.Items) == 0 && len(cleanSearchTitle) > 0 {
-			firstWord := strings.Split(cleanSearchTitle, " ")[0]
-			// Strip common trailing punctuation if the first word is short or holds a symbol
-			firstWord = strings.Map(func(r rune) rune {
-				if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-					return r
-				}
-				return -1
-			}, firstWord)
+			firstWord := cleanSearchTitle
+			if spaceIdx := strings.Index(cleanSearchTitle, " "); spaceIdx != -1 {
+				firstWord = cleanSearchTitle[:spaceIdx]
+			}
+			
+			// Strip common trailing punctuation like apostrophes or dashes from the single word
+			firstWord = strings.NewReplacer("'", "", "`", "", "-", "", ",", "", "(", "", "[", "").Replace(firstWord)
 
 			if len(firstWord) >= 1 {
 				broadParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(firstWord))
@@ -188,14 +188,11 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			}
 		}
 
-		// Use your existing AlnumOnly logic to boil both sides down to a pure comparison blob
-		// This turns "Rollin’ (Air Raid Vehicle)" and "rollin" both into "rollin"
 		targetAlnumTitle := util.NormalizeTitle(track.CleanTitle)
 		rawIncomingArtist := strings.ToLower(track.MainArtist)
 		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
 		
 		for _, item := range results.Items {
-			// Boil the Jellyfin item name down to pure alphanumeric text
 			currentAlnumItemTitle := util.NormalizeTitle(item.Name)
 		
 			// 1. Strict MusicBrainz Recording/Track ID Match
@@ -203,7 +200,7 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
 					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
-			// 2. Pure Alphanumeric Title Match (Bypasses all punctuation, casing, and bracket text)
+			// 2. Pure Alphanumeric Title Match
 			titleMatch := currentAlnumItemTitle == targetAlnumTitle
 		
 			// 3. Substring-Aware Artist Matching

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -154,7 +154,7 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 	parenthesesRe := regexp.MustCompile(`[\(\[\{].*?[\)\]\}]`)
 
 	for _, track := range tracks {
-		// Sanitize the raw SearchTerm completely to prevent Jellyfin syntax errors
+		// Clean typography drift from the search parameters
 		cleanSearchTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
 		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "`", "'")
 		cleanSearchTitle = parenthesesRe.ReplaceAllString(cleanSearchTitle, "") 
@@ -174,6 +174,9 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			return err
 		}
 
+		// DIAGNOSTIC LOG: See exactly what Jellyfin returned for this specific search term
+		slog.Debug(fmt.Sprintf("[EXPLO-DIAG] Search for '%s' returned %d results from Jellyfin", cleanSearchTitle, results.TotalRecordCount))
+
 		normalizedCleanTitle := util.NormalizeTitle(track.CleanTitle)
 		rawIncomingArtist := strings.ToLower(track.MainArtist)
 		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
@@ -183,15 +186,16 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			itemTitleCleaned = strings.ReplaceAll(itemTitleCleaned, "`", "'")
 			normalizedItemTitle := util.NormalizeTitle(itemTitleCleaned)
 		
-			// 1. Strict MusicBrainz Recording/Track ID Match
+			// DIAGNOSTIC LOG FOR EACH ITEM: See what text strings are actually being compared
+			slog.Debug(fmt.Sprintf("[EXPLO-DIAG] Comparing Track: '%s' vs Item: '%s' | Artist: '%s' vs AlbumArtist: '%s'", 
+				normalizedCleanTitle, normalizedItemTitle, normalizedMainArtist, util.NormalizeArtist(item.AlbumArtist)))
+
 			musicBrainzMatch := track.MusicBrainzTrackID != "" &&
 				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
 					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
-			// 2. Title Match
 			titleMatch := normalizedItemTitle == normalizedCleanTitle
 		
-			// 3. Substring-Aware Artist Matching
 			artistMatch := false
 			if normalizedMainArtist != "" {
 				normalizedAlbumArtist := util.NormalizeArtist(item.AlbumArtist)
@@ -213,15 +217,12 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 				}
 			}
 		
-			// NEW FIXED MATCH ACTION: If Title and Artist match perfectly, accept it!
-			// This completely bypasses any missing album subtitles or path checking constraints.
 			if musicBrainzMatch || (titleMatch && artistMatch) {
 				track.ID = item.ID
 				track.Present = true
 				break
 			}
 		
-			// Broad fallback matching using path strings if track.File happens to be populated
 			pathMatch := track.File != "" && util.ContainsFold(item.Path, track.File)
 			if artistMatch && pathMatch {
 				track.ID = item.ID

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -150,13 +150,19 @@ func (c *Jellyfin) CheckRefreshState() bool {
 }
 
 func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
-	for _, track := range tracks {
-		// Clean typography drift from the search parameters
-		cleanSearchTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
-		cleanSearchTitle = util.CleanSearchTitle(cleanSearchTitle)
+	// Match anything inside parentheses or brackets, along with the brackets themselves
+	parenthesesRe := regexp.MustCompile(`[\(\[\{].*?[\)\]\}]`)
 
-		// Added Limit=300 to ensure generic terms like "heavy metal" aren't cut off by Jellyfin's default limits
-		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(cleanSearchTitle))
+	for _, track := range tracks {
+		// 1. Sanitize the raw SearchTerm completely to prevent Jellyfin syntax errors
+		cleanSearchTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
+		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "`", "'")
+		cleanSearchTitle = parenthesesRe.ReplaceAllString(cleanSearchTitle, "") // Strip (Air Raid Vehicle), etc.
+		cleanSearchTitle = util.CleanSearchTitle(cleanSearchTitle)
+		cleanSearchTitle = strings.ToLower(cleanSearchTitle) // Force lowercase for reliable matching
+
+		// Query using our stripped down, safe search string
+		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
 
 		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+reqParam, nil, c.Cfg.Creds.Headers)
 		if err != nil {
@@ -169,36 +175,33 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 		}
 
 		normalizedCleanTitle := util.NormalizeTitle(track.CleanTitle)
-		
-		// Keep a lowercase version of the raw incoming artist string for substring fallback checks
 		rawIncomingArtist := strings.ToLower(track.MainArtist)
-		
-		// Clean the primary artist down to an alphanumeric string
 		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
 		
 		for _, item := range results.Items {
-			normalizedItemTitle := util.NormalizeTitle(strings.ReplaceAll(item.Name, "’", "'"))
+			// Normalize punctuation and layout of the current item title from Jellyfin
+			itemTitleCleaned := strings.ReplaceAll(item.Name, "’", "'")
+			itemTitleCleaned = strings.ReplaceAll(itemTitleCleaned, "`", "'")
+			normalizedItemTitle := util.NormalizeTitle(itemTitleCleaned)
 		
-			// 1. Strict MusicBrainz Recording/Track ID Match
+			// Strict MusicBrainz Recording/Track ID Match
 			musicBrainzMatch := track.MusicBrainzTrackID != "" &&
 				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
 					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
-			// 2. Title Match
+			// Title Match
 			titleMatch := normalizedItemTitle == normalizedCleanTitle
 		
-			// 3. Substring-Aware Artist Matching
+			// Substring-Aware Artist Matching
 			artistMatch := false
 			if normalizedMainArtist != "" {
 				normalizedAlbumArtist := util.NormalizeArtist(item.AlbumArtist)
 				
-				// Direct match or check if one is a substring of the other (handles "A & B" vs "A")
 				if normalizedAlbumArtist == normalizedMainArtist || 
 				   strings.Contains(normalizedMainArtist, normalizedAlbumArtist) || 
 				   strings.Contains(normalizedAlbumArtist, normalizedMainArtist) {
 					artistMatch = true
 				} else {
-					// Check individual entries in Jellyfin's artist array
 					for _, individualArtist := range item.Artists {
 						normalizedIndiv := util.NormalizeArtist(individualArtist)
 						if normalizedIndiv == normalizedMainArtist || 

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -151,14 +151,13 @@ func (c *Jellyfin) CheckRefreshState() bool {
 
 func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 	for _, track := range tracks {
-		// Clean ONLY the problematic typography drift before hitting the API.
-		// Leave the actual words, brackets, and spaces alone so Jellyfin's index matches.
+		// Clean problematic typography drift before hitting the API
 		cleanSearchTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
 		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "`", "'")
 		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "“", "\"")
 		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "”", "\"")
 
-		// Revert to the indexed SearchTerm query that successfully found your tracks
+		// 1. Primary Request: Use the reliable SearchTerm query
 		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
 
 		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+reqParam, nil, c.Cfg.Creds.Headers)
@@ -171,25 +170,33 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			return err
 		}
 
+		// 2. Fallback Request: If SearchTerm returned 0 items, try a direct Name lookup instead
+		if len(results.Items) == 0 {
+			fallbackParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&Name=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
+			fallbackBody, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+fallbackParam, nil, c.Cfg.Creds.Headers)
+			if err == nil {
+				_ = util.ParseResp(fallbackBody, &results)
+			}
+		}
+
 		normalizedCleanTitle := util.NormalizeTitle(track.CleanTitle)
 		rawIncomingArtist := strings.ToLower(track.MainArtist)
 		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
 		
 		for _, item := range results.Items {
-			// Normalize punctuation for the database items we are evaluating
 			itemTitleCleaned := strings.ReplaceAll(item.Name, "’", "'")
 			itemTitleCleaned = strings.ReplaceAll(itemTitleCleaned, "`", "'")
 			normalizedItemTitle := util.NormalizeTitle(itemTitleCleaned)
 		
-			// 1. Strict MusicBrainz Recording/Track ID Match
+			// Strict MusicBrainz Recording/Track ID Match
 			musicBrainzMatch := track.MusicBrainzTrackID != "" &&
 				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
 					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
-			// 2. Title Match
+			// Title Match
 			titleMatch := normalizedItemTitle == normalizedCleanTitle
 		
-			// 3. Substring-Aware Artist Matching
+			// Substring-Aware Artist Matching
 			artistMatch := false
 			if normalizedMainArtist != "" {
 				normalizedAlbumArtist := util.NormalizeArtist(item.AlbumArtist)

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -151,25 +151,12 @@ func (c *Jellyfin) CheckRefreshState() bool {
 
 func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 	for _, track := range tracks {
-		// Fix 1: Strip punctuation like curly apostrophes from the Title search parameter
-		cleanTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
-		cleanTitle = util.CleanSearchTitle(cleanTitle)
+		// Clean punctuation from the title to make the SearchTerm more reliable
+		cleanSearchTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
+		cleanSearchTitle = util.CleanSearchTitle(cleanSearchTitle)
 
-		// Fix 2: Isolate the absolute primary artist keyword (e.g., "Linkin Park" instead of the whole reinterpreted string)
-		// We split on common breaking words to ensure Jellyfin's search engine isn't confused
-		primaryArtist := track.MainArtist
-		for _, delimiter := range []string{" feat", " ft", " featuring", " &", " reinterpreted", " with", " x ", " and "} {
-			if idx := strings.Index(strings.ToLower(primaryArtist), delimiter); idx != -1 {
-				primaryArtist = primaryArtist[:idx]
-				break
-			}
-		}
-
-		// Fix 3: Use Jellyfin's explicit Artist and Name filters instead of a loose global SearchTerm
-		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&ArtistType=Artist&Artists=%s&Name=%s&Recursive=true&Fields=Path,ProviderIDs", 
-			url.QueryEscape(strings.TrimSpace(primaryArtist)), 
-			url.QueryEscape(strings.TrimSpace(cleanTitle)),
-		)
+		// Use the fast SearchTerm endpoint to avoid Jellyfin database timeouts
+		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Fields=Path,ProviderIDs", url.QueryEscape(cleanSearchTitle))
 
 		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+reqParam, nil, c.Cfg.Creds.Headers)
 		if err != nil {
@@ -180,43 +167,56 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 		if err = util.ParseResp(body, &results); err != nil {
 			return err
 		}
+
+		// Normalize our target fields for comparison
 		normalizedCleanTitle := util.NormalizeTitle(track.CleanTitle)
-		// 1. Keep things clean by using your StripFeat logic to isolate the true primary artist
-		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
+		
+		// Extract the absolute base primary artist name (e.g., "Linkin Park" or "Nomyn")
+		primaryArtist := track.MainArtist
+		for _, delimiter := range []string{" feat", " ft", " featuring", " &", " reinterpreted", " with", " x ", " and "} {
+			if idx := strings.Index(strings.ToLower(primaryArtist), delimiter); idx != -1 {
+				primaryArtist = primaryArtist[:idx]
+				break
+			}
+		}
+		normalizedMainArtist := util.NormalizeArtist(strings.TrimSpace(primaryArtist))
 		
 		for _, item := range results.Items {
-		    normalizedItemTitle := util.NormalizeTitle(item.Name)
+			// Normalize punctuation and layout of the current item title from Jellyfin
+			normalizedItemTitle := util.NormalizeTitle(strings.ReplaceAll(item.Name, "’", "'"))
 		
-		    musicBrainzMatch := track.MusicBrainzTrackID != "" &&
-		        (item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
-		            item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
+			// 1. Strict MusicBrainz Recording/Track ID Match
+			musicBrainzMatch := track.MusicBrainzTrackID != "" &&
+				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
+					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
-		    titleMatch := normalizedItemTitle == normalizedCleanTitle
+			// 2. Title Match (Fuzzy punctuation matched)
+			titleMatch := normalizedItemTitle == normalizedCleanTitle
 		
-		    // 2. Updated Fuzzy Artist Matching Logic
-		    artistMatch := false
-		    if normalizedMainArtist != "" {
-		        // Check if MainArtist matches AlbumArtist cleanly
-		        if util.NormalizeArtist(item.AlbumArtist) == normalizedMainArtist {
-		            artistMatch = true
-		        } else {
-		            // Loop through all artists returned by Jellyfin to find a match for the main artist
-		            for _, individualArtist := range item.Artists {
-		                if util.NormalizeArtist(individualArtist) == normalizedMainArtist {
-		                    artistMatch = true
-		                    break
-		                }
-		            }
-		        }
-		    }
+			// 3. Robust Multi-Artist / Array Match
+			artistMatch := false
+			if normalizedMainArtist != "" {
+				// Check if the primary artist matches Jellyfin's AlbumArtist field
+				if util.NormalizeArtist(item.AlbumArtist) == normalizedMainArtist {
+					artistMatch = true
+				} else {
+					// Check Jellyfin's split string array for individual artists
+					for _, individualArtist := range item.Artists {
+						if util.NormalizeArtist(individualArtist) == normalizedMainArtist {
+							artistMatch = true
+							break
+						}
+					}
+				}
+			}
 		
-		    pathMatch := util.ContainsFold(item.Path, track.File)
+			pathMatch := util.ContainsFold(item.Path, track.File)
 		
-		    if musicBrainzMatch || (titleMatch && artistMatch) {
-		        track.ID = item.ID
-		        track.Present = true
-		        break
-		    }
+			if musicBrainzMatch || (titleMatch && artistMatch) {
+				track.ID = item.ID
+				track.Present = true
+				break
+			}
 		
 			if track.File != "" && artistMatch && pathMatch {
 				track.ID = item.ID

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -168,18 +168,20 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			return err
 		}
 
-		// 2. Safe Fallback: If primary search returns 0 results, 
-		// search using just the first complete word of the song title.
+		// 2. Robust Root-Word Fallback: If primary search returns 0 results,
+		// isolate the very first continuous block of alphanumeric characters (stops at spaces, apostrophes, etc.)
 		if len(results.Items) == 0 && len(cleanSearchTitle) > 0 {
-			firstWord := cleanSearchTitle
-			if spaceIdx := strings.Index(cleanSearchTitle, " "); spaceIdx != -1 {
-				firstWord = cleanSearchTitle[:spaceIdx]
+			endIdx := 0
+			for i, r := range cleanSearchTitle {
+				if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+					endIdx = i + 1
+				} else if endIdx > 0 {
+					break
+				}
 			}
 			
-			// Strip common trailing punctuation like apostrophes or dashes from the single word
-			firstWord = strings.NewReplacer("'", "", "`", "", "-", "", ",", "", "(", "", "[", "").Replace(firstWord)
-
-			if len(firstWord) >= 1 {
+			if endIdx > 0 {
+				firstWord := cleanSearchTitle[:endIdx]
 				broadParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(firstWord))
 				broadBody, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+broadParam, nil, c.Cfg.Creds.Headers)
 				if err == nil {

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -163,30 +163,42 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			return err
 		}
 		normalizedCleanTitle := util.NormalizeTitle(track.CleanTitle)
-		normalizedMainArtist := util.NormalizeArtist(track.MainArtist)
+		// 1. Keep things clean by using your StripFeat logic to isolate the true primary artist
+		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
 		
 		for _, item := range results.Items {
-			normalizedItemTitle := util.NormalizeTitle(item.Name)
+		    normalizedItemTitle := util.NormalizeTitle(item.Name)
 		
-			// track.MusicBrainzTrackID holds a recording MBID; Jellyfin exposes that
-			// as MusicBrainzRecording. Check MusicBrainzTrack too as a fallback.
-			musicBrainzMatch := track.MusicBrainzTrackID != "" &&
-				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
-					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
+		    musicBrainzMatch := track.MusicBrainzTrackID != "" &&
+		        (item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
+		            item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
-			titleMatch := normalizedItemTitle == normalizedCleanTitle
+		    titleMatch := normalizedItemTitle == normalizedCleanTitle
 		
-			artistMatch := normalizedMainArtist != "" &&
-				(util.NormalizeArtist(item.AlbumArtist) == normalizedMainArtist ||
-					(len(item.Artists) > 0 && util.NormalizeArtist(item.Artists[0]) == normalizedMainArtist))
+		    // 2. Updated Fuzzy Artist Matching Logic
+		    artistMatch := false
+		    if normalizedMainArtist != "" {
+		        // Check if MainArtist matches AlbumArtist cleanly
+		        if util.NormalizeArtist(item.AlbumArtist) == normalizedMainArtist {
+		            artistMatch = true
+		        } else {
+		            // Loop through all artists returned by Jellyfin to find a match for the main artist
+		            for _, individualArtist := range item.Artists {
+		                if util.NormalizeArtist(individualArtist) == normalizedMainArtist {
+		                    artistMatch = true
+		                    break
+		                }
+		            }
+		        }
+		    }
 		
-			pathMatch := util.ContainsFold(item.Path, track.File)
+		    pathMatch := util.ContainsFold(item.Path, track.File)
 		
-			if musicBrainzMatch || (titleMatch && artistMatch) {
-				track.ID = item.ID
-				track.Present = true
-				break
-			}
+		    if musicBrainzMatch || (titleMatch && artistMatch) {
+		        track.ID = item.ID
+		        track.Present = true
+		        break
+		    }
 		
 			if track.File != "" && artistMatch && pathMatch {
 				track.ID = item.ID

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -159,10 +159,10 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "`", "'")
 		cleanSearchTitle = parenthesesRe.ReplaceAllString(cleanSearchTitle, "") 
 		cleanSearchTitle = util.CleanSearchTitle(cleanSearchTitle)
-		cleanSearchTitle = strings.ToLower(cleanSearchTitle) 
 
-		// Query using our stripped down, safe search string
-		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
+		// FIX: Use explicit Name lookup instead of volatile SearchTerm. 
+		// This bypasses the search indexing bugs that cause Jellyfin to return 0 results.
+		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&Name=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
 
 		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+reqParam, nil, c.Cfg.Creds.Headers)
 		if err != nil {
@@ -174,9 +174,6 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			return err
 		}
 
-		// DIAGNOSTIC LOG: See exactly what Jellyfin returned for this specific search term
-		slog.Debug(fmt.Sprintf("[EXPLO-DIAG] Search for '%s' returned %d results from Jellyfin", cleanSearchTitle, results.TotalRecordCount))
-
 		normalizedCleanTitle := util.NormalizeTitle(track.CleanTitle)
 		rawIncomingArtist := strings.ToLower(track.MainArtist)
 		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
@@ -186,16 +183,15 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			itemTitleCleaned = strings.ReplaceAll(itemTitleCleaned, "`", "'")
 			normalizedItemTitle := util.NormalizeTitle(itemTitleCleaned)
 		
-			// DIAGNOSTIC LOG FOR EACH ITEM: See what text strings are actually being compared
-			slog.Debug(fmt.Sprintf("[EXPLO-DIAG] Comparing Track: '%s' vs Item: '%s' | Artist: '%s' vs AlbumArtist: '%s'", 
-				normalizedCleanTitle, normalizedItemTitle, normalizedMainArtist, util.NormalizeArtist(item.AlbumArtist)))
-
+			// 1. Strict MusicBrainz Recording/Track ID Match
 			musicBrainzMatch := track.MusicBrainzTrackID != "" &&
 				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
 					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
+			// 2. Title Match
 			titleMatch := normalizedItemTitle == normalizedCleanTitle
 		
+			// 3. Substring-Aware Artist Matching
 			artistMatch := false
 			if normalizedMainArtist != "" {
 				normalizedAlbumArtist := util.NormalizeArtist(item.AlbumArtist)
@@ -218,13 +214,6 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			}
 		
 			if musicBrainzMatch || (titleMatch && artistMatch) {
-				track.ID = item.ID
-				track.Present = true
-				break
-			}
-		
-			pathMatch := track.File != "" && util.ContainsFold(item.Path, track.File)
-			if artistMatch && pathMatch {
 				track.ID = item.ID
 				track.Present = true
 				break

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -151,18 +151,16 @@ func (c *Jellyfin) CheckRefreshState() bool {
 }
 
 func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
-	parenthesesRe := regexp.MustCompile(`[\(\[\{].*?[\)\]\}]`)
-
 	for _, track := range tracks {
-		// Clean typography drift from the search parameters
+		// Clean ONLY the problematic typography drift before hitting the API.
+		// Leave the actual words, brackets, and spaces alone so Jellyfin's index matches.
 		cleanSearchTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
 		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "`", "'")
-		cleanSearchTitle = parenthesesRe.ReplaceAllString(cleanSearchTitle, "") 
-		cleanSearchTitle = util.CleanSearchTitle(cleanSearchTitle)
+		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "“", "\"")
+		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "”", "\"")
 
-		// FIX: Use explicit Name lookup instead of volatile SearchTerm. 
-		// This bypasses the search indexing bugs that cause Jellyfin to return 0 results.
-		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&Name=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
+		// Revert to the indexed SearchTerm query that successfully found your tracks
+		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
 
 		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+reqParam, nil, c.Cfg.Creds.Headers)
 		if err != nil {
@@ -179,6 +177,7 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
 		
 		for _, item := range results.Items {
+			// Normalize punctuation for the database items we are evaluating
 			itemTitleCleaned := strings.ReplaceAll(item.Name, "’", "'")
 			itemTitleCleaned = strings.ReplaceAll(itemTitleCleaned, "`", "'")
 			normalizedItemTitle := util.NormalizeTitle(itemTitleCleaned)

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"regexp" // ➕ Add this line right here
 	"strings"
 	"log/slog"
 

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -167,15 +167,24 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 		if err = util.ParseResp(body, &results); err != nil {
 			return err
 		}
+		// 2. Precise Word-Isolation Fallback: If primary search returns 0 results, 
+		// fetch using just the first complete word of the song title to avoid index truncation.
+		if len(results.Items) == 0 && len(cleanSearchTitle) > 0 {
+			firstWord := strings.Split(cleanSearchTitle, " ")[0]
+			// Strip common trailing punctuation if the first word is short or holds a symbol
+			firstWord = strings.Map(func(r rune) rune {
+				if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+					return r
+				}
+				return -1
+			}, firstWord)
 
-		// 2. Fail-safe: If Jellyfin returns 0 results, query by the first letter of the title.
-		// This forces Jellyfin to give us the raw data pool so we can parse it in memory.
-		if len(results.Items) == 0 && len(cleanSearchTitle) >= 1 {
-			broadQuery := strings.ToLower(cleanSearchTitle[:1])
-			broadParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(broadQuery))
-			broadBody, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+broadParam, nil, c.Cfg.Creds.Headers)
-			if err == nil {
-				_ = util.ParseResp(broadBody, &results)
+			if len(firstWord) >= 1 {
+				broadParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(firstWord))
+				broadBody, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+broadParam, nil, c.Cfg.Creds.Headers)
+				if err == nil {
+					_ = util.ParseResp(broadBody, &results)
+				}
 			}
 		}
 

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -151,15 +151,13 @@ func (c *Jellyfin) CheckRefreshState() bool {
 
 func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 	for _, track := range tracks {
-		// Clean problematic typography drift before hitting the API
+		// Clean typography drift from the search parameters
 		cleanSearchTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
 		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "`", "'")
-		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "“", "\"")
-		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "”", "\"")
+		cleanSearchTitle = strings.TrimSpace(cleanSearchTitle)
 
-		// 1. Primary Request: Use the reliable SearchTerm query
-		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
-
+		// 1. Fetch candidates using the standard search term
+		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(cleanSearchTitle))
 		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+reqParam, nil, c.Cfg.Creds.Headers)
 		if err != nil {
 			return err
@@ -170,33 +168,36 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			return err
 		}
 
-		// 2. Fallback Request: If SearchTerm returned 0 items, try a direct Name lookup instead
-		if len(results.Items) == 0 {
-			fallbackParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&Name=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
-			fallbackBody, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+fallbackParam, nil, c.Cfg.Creds.Headers)
+		// 2. Fail-safe: If Jellyfin returns 0 results, query by the first letter of the title.
+		// This forces Jellyfin to give us the raw data pool so we can parse it in memory.
+		if len(results.Items) == 0 && len(cleanSearchTitle) >= 1 {
+			broadQuery := strings.ToLower(cleanSearchTitle[:1])
+			broadParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(broadQuery))
+			broadBody, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+broadParam, nil, c.Cfg.Creds.Headers)
 			if err == nil {
-				_ = util.ParseResp(fallbackBody, &results)
+				_ = util.ParseResp(broadBody, &results)
 			}
 		}
 
-		normalizedCleanTitle := util.NormalizeTitle(track.CleanTitle)
+		// Use your existing AlnumOnly logic to boil both sides down to a pure comparison blob
+		// This turns "Rollin’ (Air Raid Vehicle)" and "rollin" both into "rollin"
+		targetAlnumTitle := util.NormalizeTitle(track.CleanTitle)
 		rawIncomingArtist := strings.ToLower(track.MainArtist)
 		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
 		
 		for _, item := range results.Items {
-			itemTitleCleaned := strings.ReplaceAll(item.Name, "’", "'")
-			itemTitleCleaned = strings.ReplaceAll(itemTitleCleaned, "`", "'")
-			normalizedItemTitle := util.NormalizeTitle(itemTitleCleaned)
+			// Boil the Jellyfin item name down to pure alphanumeric text
+			currentAlnumItemTitle := util.NormalizeTitle(item.Name)
 		
-			// Strict MusicBrainz Recording/Track ID Match
+			// 1. Strict MusicBrainz Recording/Track ID Match
 			musicBrainzMatch := track.MusicBrainzTrackID != "" &&
 				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
 					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
-			// Title Match
-			titleMatch := normalizedItemTitle == normalizedCleanTitle
+			// 2. Pure Alphanumeric Title Match (Bypasses all punctuation, casing, and bracket text)
+			titleMatch := currentAlnumItemTitle == targetAlnumTitle
 		
-			// Substring-Aware Artist Matching
+			// 3. Substring-Aware Artist Matching
 			artistMatch := false
 			if normalizedMainArtist != "" {
 				normalizedAlbumArtist := util.NormalizeArtist(item.AlbumArtist)

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -41,7 +41,8 @@ type Audios struct {
 }
 
 type ProviderIds struct {
-	MusicBrainzTrack        string `json:"MusicBrainzTrack"`
+	MusicBrainzTrack     string `json:"MusicBrainzTrack"`
+	MusicBrainzRecording string `json:"MusicBrainzRecording"`
 }
 
 type Items struct {
@@ -162,21 +163,31 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			return err
 		}
 		normalizedCleanTitle := util.NormalizeTitle(track.CleanTitle)
+		normalizedMainArtist := util.NormalizeArtist(track.MainArtist)
+		
 		for _, item := range results.Items {
-
 			normalizedItemTitle := util.NormalizeTitle(item.Name)
-
-			musicBrainzMatch := track.MusicBrainzTrackID != "" && item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID
+		
+			// track.MusicBrainzTrackID holds a recording MBID; Jellyfin exposes that
+			// as MusicBrainzRecording. Check MusicBrainzTrack too as a fallback.
+			musicBrainzMatch := track.MusicBrainzTrackID != "" &&
+				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
+					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
+		
 			titleMatch := normalizedItemTitle == normalizedCleanTitle
-			artistMatch := strings.EqualFold(item.AlbumArtist, track.MainArtist) || (len(item.Artists) > 0 && strings.EqualFold(item.Artists[0], track.MainArtist))
-			pathMatch := util.ContainsFold(item.Path,track.File)
-			
+		
+			artistMatch := normalizedMainArtist != "" &&
+				(util.NormalizeArtist(item.AlbumArtist) == normalizedMainArtist ||
+					(len(item.Artists) > 0 && util.NormalizeArtist(item.Artists[0]) == normalizedMainArtist))
+		
+			pathMatch := util.ContainsFold(item.Path, track.File)
+		
 			if musicBrainzMatch || (titleMatch && artistMatch) {
 				track.ID = item.ID
 				track.Present = true
 				break
 			}
-
+		
 			if track.File != "" && artistMatch && pathMatch {
 				track.ID = item.ID
 				track.Present = true

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -151,16 +151,15 @@ func (c *Jellyfin) CheckRefreshState() bool {
 }
 
 func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
-	// Match anything inside parentheses or brackets, along with the brackets themselves
 	parenthesesRe := regexp.MustCompile(`[\(\[\{].*?[\)\]\}]`)
 
 	for _, track := range tracks {
-		// 1. Sanitize the raw SearchTerm completely to prevent Jellyfin syntax errors
+		// Sanitize the raw SearchTerm completely to prevent Jellyfin syntax errors
 		cleanSearchTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
 		cleanSearchTitle = strings.ReplaceAll(cleanSearchTitle, "`", "'")
-		cleanSearchTitle = parenthesesRe.ReplaceAllString(cleanSearchTitle, "") // Strip (Air Raid Vehicle), etc.
+		cleanSearchTitle = parenthesesRe.ReplaceAllString(cleanSearchTitle, "") 
 		cleanSearchTitle = util.CleanSearchTitle(cleanSearchTitle)
-		cleanSearchTitle = strings.ToLower(cleanSearchTitle) // Force lowercase for reliable matching
+		cleanSearchTitle = strings.ToLower(cleanSearchTitle) 
 
 		// Query using our stripped down, safe search string
 		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(strings.TrimSpace(cleanSearchTitle)))
@@ -180,20 +179,19 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
 		
 		for _, item := range results.Items {
-			// Normalize punctuation and layout of the current item title from Jellyfin
 			itemTitleCleaned := strings.ReplaceAll(item.Name, "’", "'")
 			itemTitleCleaned = strings.ReplaceAll(itemTitleCleaned, "`", "'")
 			normalizedItemTitle := util.NormalizeTitle(itemTitleCleaned)
 		
-			// Strict MusicBrainz Recording/Track ID Match
+			// 1. Strict MusicBrainz Recording/Track ID Match
 			musicBrainzMatch := track.MusicBrainzTrackID != "" &&
 				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
 					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
-			// Title Match
+			// 2. Title Match
 			titleMatch := normalizedItemTitle == normalizedCleanTitle
 		
-			// Substring-Aware Artist Matching
+			// 3. Substring-Aware Artist Matching
 			artistMatch := false
 			if normalizedMainArtist != "" {
 				normalizedAlbumArtist := util.NormalizeArtist(item.AlbumArtist)
@@ -215,15 +213,17 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 				}
 			}
 		
-			pathMatch := util.ContainsFold(item.Path, track.File)
-		
+			// NEW FIXED MATCH ACTION: If Title and Artist match perfectly, accept it!
+			// This completely bypasses any missing album subtitles or path checking constraints.
 			if musicBrainzMatch || (titleMatch && artistMatch) {
 				track.ID = item.ID
 				track.Present = true
 				break
 			}
 		
-			if track.File != "" && artistMatch && pathMatch {
+			// Broad fallback matching using path strings if track.File happens to be populated
+			pathMatch := track.File != "" && util.ContainsFold(item.Path, track.File)
+			if artistMatch && pathMatch {
 				track.ID = item.ID
 				track.Present = true
 				break

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -151,7 +151,25 @@ func (c *Jellyfin) CheckRefreshState() bool {
 
 func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 	for _, track := range tracks {
-		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Fields=Path,ProviderIDs", url.QueryEscape(util.CleanSearchTitle(track.CleanTitle)))
+		// Fix 1: Strip punctuation like curly apostrophes from the Title search parameter
+		cleanTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
+		cleanTitle = util.CleanSearchTitle(cleanTitle)
+
+		// Fix 2: Isolate the absolute primary artist keyword (e.g., "Linkin Park" instead of the whole reinterpreted string)
+		// We split on common breaking words to ensure Jellyfin's search engine isn't confused
+		primaryArtist := track.MainArtist
+		for _, delimiter := range []string{" feat", " ft", " featuring", " &", " reinterpreted", " with", " x ", " and "} {
+			if idx := strings.Index(strings.ToLower(primaryArtist), delimiter); idx != -1 {
+				primaryArtist = primaryArtist[:idx]
+				break
+			}
+		}
+
+		// Fix 3: Use Jellyfin's explicit Artist and Name filters instead of a loose global SearchTerm
+		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&ArtistType=Artist&Artists=%s&Name=%s&Recursive=true&Fields=Path,ProviderIDs", 
+			url.QueryEscape(strings.TrimSpace(primaryArtist)), 
+			url.QueryEscape(strings.TrimSpace(cleanTitle)),
+		)
 
 		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+reqParam, nil, c.Cfg.Creds.Headers)
 		if err != nil {

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -151,12 +151,12 @@ func (c *Jellyfin) CheckRefreshState() bool {
 
 func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 	for _, track := range tracks {
-		// Clean punctuation from the title to make the SearchTerm more reliable
+		// Clean typography drift from the search parameters
 		cleanSearchTitle := strings.ReplaceAll(track.CleanTitle, "’", "'")
 		cleanSearchTitle = util.CleanSearchTitle(cleanSearchTitle)
 
-		// Use the fast SearchTerm endpoint to avoid Jellyfin database timeouts
-		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Fields=Path,ProviderIDs", url.QueryEscape(cleanSearchTitle))
+		// Added Limit=300 to ensure generic terms like "heavy metal" aren't cut off by Jellyfin's default limits
+		reqParam := fmt.Sprintf("/Items?IncludeMediaTypes=Audio&SearchTerm=%s&Recursive=true&Limit=300&Fields=Path,ProviderIDs", url.QueryEscape(cleanSearchTitle))
 
 		body, err := c.HttpClient.MakeRequest("GET", c.Cfg.URL+reqParam, nil, c.Cfg.Creds.Headers)
 		if err != nil {
@@ -168,21 +168,15 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 			return err
 		}
 
-		// Normalize our target fields for comparison
 		normalizedCleanTitle := util.NormalizeTitle(track.CleanTitle)
 		
-		// Extract the absolute base primary artist name (e.g., "Linkin Park" or "Nomyn")
-		primaryArtist := track.MainArtist
-		for _, delimiter := range []string{" feat", " ft", " featuring", " &", " reinterpreted", " with", " x ", " and "} {
-			if idx := strings.Index(strings.ToLower(primaryArtist), delimiter); idx != -1 {
-				primaryArtist = primaryArtist[:idx]
-				break
-			}
-		}
-		normalizedMainArtist := util.NormalizeArtist(strings.TrimSpace(primaryArtist))
+		// Keep a lowercase version of the raw incoming artist string for substring fallback checks
+		rawIncomingArtist := strings.ToLower(track.MainArtist)
+		
+		// Clean the primary artist down to an alphanumeric string
+		normalizedMainArtist := util.NormalizeArtist(util.StripFeat(track.MainArtist))
 		
 		for _, item := range results.Items {
-			// Normalize punctuation and layout of the current item title from Jellyfin
 			normalizedItemTitle := util.NormalizeTitle(strings.ReplaceAll(item.Name, "’", "'"))
 		
 			// 1. Strict MusicBrainz Recording/Track ID Match
@@ -190,19 +184,26 @@ func (c *Jellyfin) SearchSongs(tracks []*models.Track) error {
 				(item.ProviderIds.MusicBrainzRecording == track.MusicBrainzTrackID ||
 					item.ProviderIds.MusicBrainzTrack == track.MusicBrainzTrackID)
 		
-			// 2. Title Match (Fuzzy punctuation matched)
+			// 2. Title Match
 			titleMatch := normalizedItemTitle == normalizedCleanTitle
 		
-			// 3. Robust Multi-Artist / Array Match
+			// 3. Substring-Aware Artist Matching
 			artistMatch := false
 			if normalizedMainArtist != "" {
-				// Check if the primary artist matches Jellyfin's AlbumArtist field
-				if util.NormalizeArtist(item.AlbumArtist) == normalizedMainArtist {
+				normalizedAlbumArtist := util.NormalizeArtist(item.AlbumArtist)
+				
+				// Direct match or check if one is a substring of the other (handles "A & B" vs "A")
+				if normalizedAlbumArtist == normalizedMainArtist || 
+				   strings.Contains(normalizedMainArtist, normalizedAlbumArtist) || 
+				   strings.Contains(normalizedAlbumArtist, normalizedMainArtist) {
 					artistMatch = true
 				} else {
-					// Check Jellyfin's split string array for individual artists
+					// Check individual entries in Jellyfin's artist array
 					for _, individualArtist := range item.Artists {
-						if util.NormalizeArtist(individualArtist) == normalizedMainArtist {
+						normalizedIndiv := util.NormalizeArtist(individualArtist)
+						if normalizedIndiv == normalizedMainArtist || 
+						   strings.Contains(normalizedMainArtist, normalizedIndiv) ||
+						   util.ContainsFold(rawIncomingArtist, individualArtist) {
 							artistMatch = true
 							break
 						}

--- a/src/client/jellyfin.go
+++ b/src/client/jellyfin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"regexp" // ➕ Add this line right here
 	"strings"
 	"log/slog"
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -96,6 +96,7 @@ type SubsonicConfig struct {
 type DownloadConfig struct {
 	DownloadDir       string `env:"DOWNLOAD_DIR" env-default:"/data/"`
 	PathTemplate	  string `env:"PATH_TEMPLATE"`
+	DownloadAttempts  int    `env:"DOWNLOAD_ATTEMPTS" env-default:"3"`
 	Youtube           Youtube
 	YoutubeMusic      YoutubeMusic
 	Slskd             Slskd

--- a/src/downloader/downloader.go
+++ b/src/downloader/downloader.go
@@ -33,6 +33,23 @@ type Downloader interface {
 	Monitor
 }
 
+// retry runs fn up to attempts times with linear backoff, returning nil on the
+// first success. Used for transient network failures on query/download.
+func retry(attempts int, baseDelay time.Duration, label string, fn func() error) error {
+	var err error
+	for i := 1; i <= attempts; i++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		if i < attempts {
+			slog.Warn("retrying after failure",
+				"step", label, "attempt", i, "max", attempts, "context", err.Error())
+			time.Sleep(time.Duration(i) * baseDelay)
+		}
+	}
+	return err
+}
+
 // get download services from config and append them to DownloadClient
 func NewDownloader(cfg *cfg.DownloadConfig, httpClient *util.HttpClient, filterLocal bool) (*DownloadClient, error) {
 	var downloader []Downloader
@@ -86,20 +103,31 @@ func (c *DownloadClient) StartDownload(tracks *[]*models.Track) {
 					return err
 				}
 
-				if err := d.QueryTrack(track); err != nil {
+				attempts := c.Cfg.DownloadAttempts
+				if attempts < 1 {
+					attempts = 1
+				}
+	
+				if err := retry(attempts, 3*time.Second, "query", func() error {
+					if werr := limiter.Wait(ctx); werr != nil {
+						return werr
+					}
+					return d.QueryTrack(track)
+				}); err != nil {
 					slog.Warn(err.Error())
 					return nil
 				}
-
-				if err := limiter.Wait(ctx); err != nil {
-					return err
-				}
-
-				if err := d.GetTrack(track); err != nil {
+	
+				if err := retry(attempts, 3*time.Second, "download", func() error {
+					if werr := limiter.Wait(ctx); werr != nil {
+						return werr
+					}
+					return d.GetTrack(track)
+				}); err != nil {
 					slog.Warn(err.Error())
 					return nil
 				}
-
+	
 				return nil
 			})
 		}

--- a/src/util/sanitize.go
+++ b/src/util/sanitize.go
@@ -9,8 +9,31 @@ var (
 	filenameRe     = regexp.MustCompile(`[^\p{L}\d._,\-]+`)
 	alnumRe        = regexp.MustCompile(`[^\p{L}\d]+`)
 	featTailRe     = regexp.MustCompile(`(?i)\s*[\(\[\{]\s*(feat\.?|featuring|ft\.?|with)\s[^\)\]\}]*[\)\]\}]\s*$`)
+	featBareRe     = regexp.MustCompile(`(?i)\s+(feat\.?|featuring|ft\.?)\s+.*$`)
 	remasterTailRe = regexp.MustCompile(`(?i)\s*[-–—]\s*\d{4}\s*remaster(ed)?\s*$`)
 )
+
+// StripFeat removes a trailing "feat./ft./featuring …" clause, whether
+// parenthesized "(feat. X)" or bare " feat. X". Works for titles and artists.
+func StripFeat(s string) string {
+	s = featTailRe.ReplaceAllString(s, "")
+	s = featBareRe.ReplaceAllString(s, "")
+	return strings.TrimSpace(s)
+}
+
+// NormalizeTitle strips feat annotations and "- YYYY Remaster" suffixes,
+// lowercases, and reduces to alphanumeric-only for fuzzy comparison.
+func NormalizeTitle(s string) string {
+	s = StripFeat(s)
+	s = remasterTailRe.ReplaceAllString(s, "")
+	return AlnumOnly(strings.ToLower(s))
+}
+
+// NormalizeArtist strips a trailing feat clause and reduces to
+// alphanumeric-only, so "Rihanna feat. Eminem" and "Rihanna" compare equal.
+func NormalizeArtist(s string) string {
+	return AlnumOnly(strings.ToLower(StripFeat(s)))
+}
 
 // CleanSearchTitle strips trailing (feat. …) and "- 2011 Remaster" suffixes
 // but keeps the title human-readable for use in search API queries.
@@ -18,14 +41,6 @@ func CleanSearchTitle(s string) string {
 	s = featTailRe.ReplaceAllString(s, "")
 	s = remasterTailRe.ReplaceAllString(s, "")
 	return strings.TrimSpace(s)
-}
-
-// NormalizeTitle strips trailing (feat. …) annotations, lowercases,
-// and reduces to alphanumeric-only for fuzzy title comparison.
-func NormalizeTitle(s string) string {
-	s = featTailRe.ReplaceAllString(s, "")
-	s = remasterTailRe.ReplaceAllString(s, "")
-	return AlnumOnly(strings.ToLower(s))
 }
 
 // FilenameSafe replaces characters unsafe for filenames with '_'

--- a/src/util/sanitize.go
+++ b/src/util/sanitize.go
@@ -8,10 +8,43 @@ import (
 var (
 	filenameRe     = regexp.MustCompile(`[^\p{L}\d._,\-]+`)
 	alnumRe        = regexp.MustCompile(`[^\p{L}\d]+`)
+	
+	// Captures the parts before and after a featuring clause
+	featSplitRe    = regexp.MustCompile(`(?i)\s+(?:feat\.?|featuring|ft\.?|with)\s+`)
+	
+	// Existing regexes kept for compatibility
 	featTailRe     = regexp.MustCompile(`(?i)\s*[\(\[\{]\s*(feat\.?|featuring|ft\.?|with)\s[^\)\]\}]*[\)\]\}]\s*$`)
 	featBareRe     = regexp.MustCompile(`(?i)\s+(feat\.?|featuring|ft\.?)\s+.*$`)
 	remasterTailRe = regexp.MustCompile(`(?i)\s*[-–—]\s*\d{4}\s*remaster(ed)?\s*$`)
+	
+	// Clean up internal brackets inside featuring clauses if parenthesized: "(feat. Rahzel)" -> "Rahzel"
+	bracketTrimRe  = regexp.MustCompile(`[()\[\]{}]`)
 )
+
+// ConvertFeatToSemicolon rewrites "Artist A feat. Artist B" to "Artist A; Artist B"
+// This aligns string formatting directly with Jellyfin's multi-artist tracking schema.
+func ConvertFeatToSemicolon(s string) string {
+	if !featSplitRe.MatchString(s) && !featTailRe.MatchString(s) {
+		return strings.TrimSpace(s)
+	}
+	
+	// Handle parenthesized features like: Bring Me the Horizon (feat. Rahzel)
+	if featTailRe.MatchString(s) {
+		cleaned := bracketTrimRe.ReplaceAllString(s, "")
+		parts := featSplitRe.Split(cleaned, 2)
+		if len(parts) == 2 {
+			return strings.TrimSpace(parts[0]) + "; " + strings.TrimSpace(parts[1])
+		}
+	}
+
+	// Handle bare features like: Bring Me the Horizon feat. Rahzel
+	parts := featSplitRe.Split(s, 2)
+	if len(parts) == 2 {
+		return strings.TrimSpace(parts[0]) + "; " + strings.TrimSpace(parts[1])
+	}
+	
+	return strings.TrimSpace(s)
+}
 
 // StripFeat removes a trailing "feat./ft./featuring …" clause, whether
 // parenthesized "(feat. X)" or bare " feat. X". Works for titles and artists.
@@ -29,10 +62,11 @@ func NormalizeTitle(s string) string {
 	return AlnumOnly(strings.ToLower(s))
 }
 
-// NormalizeArtist strips a trailing feat clause and reduces to
-// alphanumeric-only, so "Rihanna feat. Eminem" and "Rihanna" compare equal.
+// NormalizeArtist normalizes featuring clauses to semicolons instead of dropping them,
+// ensuring accurate database alignment for tracks with multi-artist records.
 func NormalizeArtist(s string) string {
-	return AlnumOnly(strings.ToLower(StripFeat(s)))
+	s = ConvertFeatToSemicolon(s)
+	return strings.ToLower(s)
 }
 
 // CleanSearchTitle strips trailing (feat. …) and "- 2011 Remaster" suffixes


### PR DESCRIPTION
Hit my head against the wall until eventually slapping this into Gemini repeatedly until weeding out various issues. Finally got it to a 100% success rate on downloaded tracks making it to the resulting playlist.

Changes:
Alphanumeric Matching: Replaced string matches with alphanumeric-only normalization comparisons on both sides (currentAlnumItemTitle == targetAlnumTitle) to bypass typography differences (e.g., curly vs. straight apostrophes like Where’d and Where'd).

Array/Substring Multi-Artist Tracking: 
Changed the artist matching verification block to evaluate elements against Jellyfin’s discrete split-string JSON array slices (item.Artists). This helps handle collaborations (e.g., Artist A & Artist B vs Artist A feat. Artist B).

Result Pool Expansion:
Increased the API query fetch scope to Limit=300 to prevent Jellyfin from truncating matching tracks inside generic search pools.

Fuzzy Root-Word Fallback Strategy:
Implemented a non-alphanumeric split fail-safe. If an exact database query fails due to complex brackets or parentheses syntax breaking the index parser, the code falls back to searching Jellyfin by the track's first continuous block of alphanumeric characters (e.g., matching Rollin' (Air Raid Vehicle) seamlessly via a root search for Rollin).