### PR TITLE
feat(chart): add helm chart for kubernetes

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -1,0 +1,48 @@
+name: Chart CI
+
+on:
+  pull_request:
+    paths:
+      - charts/**
+      - .github/workflows/chart-ci.yml
+      - .github/workflows/chart-release.yml
+      - .kube-linter.yaml
+  push:
+    branches:
+      - dev
+    paths:
+      - charts/**
+      - .github/workflows/chart-ci.yml
+      - .github/workflows/chart-release.yml
+      - .kube-linter.yaml
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Lint chart
+        run: helm lint charts/explo --strict
+
+      - name: Render chart
+        run: |
+          helm template test charts/explo
+          helm template test charts/explo \
+            --set auth.username=admin \
+            --set auth.password=ci-only
+          helm template test charts/explo \
+            --set persistence.media.existingClaim=media-pvc \
+            --set persistence.media.subPath=explo
+          helm template test charts/explo \
+            --set ingress.enabled=true \
+            --set ingress.className=traefik \
+            --set-json 'ingress.hosts=[{"host":"explo.example.com","paths":[{"path":"/","pathType":"Prefix"}]}]'
+
+      - name: Lint manifests
+        uses: stackrox/kube-linter-action@v1
+        with:
+          directory: charts/explo
+          config: .kube-linter.yaml

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,112 @@
+name: Chart Release
+
+on:
+  workflow_run:
+    workflows:
+      - Latest Release
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          TAG=$(git tag -l 'v*' --points-at "$SHA" | sort -V | tail -1)
+          if [ -z "$TAG" ]; then
+            echo "No v* tag found for ${SHA}; skipping chart publish"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          VERSION="${TAG#v}"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip when chart is missing
+        id: chart
+        if: steps.tag.outputs.skip != 'true'
+        run: |
+          if [ ! -f charts/explo/Chart.yaml ]; then
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No chart at this tag"
+            exit 0
+          fi
+          echo "present=true" >> "$GITHUB_OUTPUT"
+
+      - uses: azure/setup-helm@v4
+        if: steps.tag.outputs.skip != 'true' && steps.chart.outputs.present == 'true'
+
+      - name: Package chart
+        if: steps.tag.outputs.skip != 'true' && steps.chart.outputs.present == 'true'
+        run: |
+          mkdir -p dist
+          helm package charts/explo \
+            --version "${{ steps.tag.outputs.version }}" \
+            --app-version "${{ steps.tag.outputs.tag }}" \
+            --destination dist
+          echo "package=${GITHUB_WORKSPACE}/dist/$(ls dist)" >> "$GITHUB_ENV"
+
+      - name: Upload release asset
+        if: steps.tag.outputs.skip != 'true' && steps.chart.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" "$package" --clobber
+
+      - name: Publish gh-pages
+        if: steps.tag.outputs.skip != 'true' && steps.chart.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PAGES_DIR="${RUNNER_TEMP}/gh-pages"
+          REPO="${{ github.repository }}"
+          PAGES_URL="https://lumepart.github.io/Explo"
+          TAG="${{ steps.tag.outputs.tag }}"
+
+          if git ls-remote --exit-code --heads "https://github.com/${REPO}.git" gh-pages >/dev/null 2>&1; then
+            git clone --branch gh-pages \
+              "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
+              "$PAGES_DIR"
+          else
+            mkdir -p "$PAGES_DIR"
+            cd "$PAGES_DIR"
+            git init
+            git checkout -b gh-pages
+            git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          fi
+
+          cp "$package" "$PAGES_DIR/"
+          if [ -f pages/index.html ]; then
+            cp pages/index.html "$PAGES_DIR/index.html"
+          fi
+
+          if [ -f "$PAGES_DIR/index.yaml" ]; then
+            helm repo index "$PAGES_DIR" --url "$PAGES_URL" --merge "$PAGES_DIR/index.yaml"
+          else
+            helm repo index "$PAGES_DIR" --url "$PAGES_URL"
+          fi
+
+          cd "$PAGES_DIR"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          if git diff --staged --quiet; then
+            echo "No gh-pages changes for ${TAG}"
+            exit 0
+          fi
+          git commit -m "chore(chart): publish ${TAG}"
+          git push origin gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 tmp/
 .air.toml
 logs/
-explo
+/explo
 src/web/dist/
 src/web/frontend/node_modules/
 /cache

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,6 @@
+checks:
+  exclude:
+    - no-read-only-root-fs
+    - run-as-non-root
+    - unset-cpu-requirements
+    - unset-memory-requirements

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Or jump directly to:
 - [FAQ](https://github.com/LumePart/Explo/wiki/8.-FAQ) – Common questions
 
 
+## Kubernetes
+
+```bash
+helm repo add explo https://lumepart.github.io/Explo && helm repo update
+helm install explo explo/explo --namespace explo --create-namespace
+```
+
+See [charts/explo/README.md](charts/explo/README.md).
+
 ## Acknowledgements
 
 Explo uses the following 3rd-party libraries:

--- a/charts/explo/.helmignore
+++ b/charts/explo/.helmignore
@@ -1,0 +1,13 @@
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/

--- a/charts/explo/Chart.yaml
+++ b/charts/explo/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: explo
+description: Helm chart for Explo music discovery
+type: application
+version: 0.0.0
+appVersion: dev
+home: https://github.com/LumePart/Explo
+sources:
+  - https://github.com/LumePart/Explo
+maintainers:
+  - name: LumePart
+    url: https://github.com/LumePart
+keywords:
+  - explo
+  - music
+  - listenbrainz
+  - jellyfin

--- a/charts/explo/README.md
+++ b/charts/explo/README.md
@@ -1,0 +1,47 @@
+# explo
+
+Helm chart for [Explo](https://github.com/LumePart/Explo).
+
+## Install
+
+```bash
+helm repo add explo https://lumepart.github.io/Explo
+helm repo update
+helm install explo explo/explo --namespace explo --create-namespace
+```
+
+## Example values
+
+```yaml
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: explo.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: explo-tls
+      hosts: [explo.example.com]
+
+persistence:
+  config:
+    storageClass: longhorn
+  media:
+    existingClaim: music-library
+    subPath: explo
+
+extraEnv:
+  EXPLO_SYSTEM: jellyfin
+  SYSTEM_URL: http://jellyfin.jellyfin.svc.cluster.local:8096
+  API_KEY: your-api-key
+  LIBRARY_NAME: Music
+```
+
+
+Config is stored under `/opt/explo/config` (`WEB_ENV_PATH`). Downloads go to `/data`.
+
+See `values.yaml` for all knobs.

--- a/charts/explo/templates/NOTES.txt
+++ b/charts/explo/templates/NOTES.txt
@@ -1,0 +1,9 @@
+Explo is installed in namespace {{ .Release.Namespace }}.
+
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{- if $.Values.ingress.tls }}s{{- end }}://{{ .host }}
+{{- end }}
+{{- else }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "explo.fullname" . }} 7288:{{ .Values.service.port }}
+{{- end }}

--- a/charts/explo/templates/_helpers.tpl
+++ b/charts/explo/templates/_helpers.tpl
@@ -1,0 +1,95 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "explo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "explo.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "explo.labels" -}}
+helm.sh/chart: {{ include "explo.name" . }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "explo.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "explo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "explo.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Image tag defaults to Chart appVersion.
+*/}}
+{{- define "explo.imageTag" -}}
+{{- .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Auth secret name when using inline credentials.
+*/}}
+{{- define "explo.authSecretName" -}}
+{{- if .Values.auth.existingSecret }}
+{{- .Values.auth.existingSecret }}
+{{- else }}
+{{- include "explo.fullname" . }}-auth
+{{- end }}
+{{- end }}
+
+{{/*
+True when UI credentials are injected at install time.
+*/}}
+{{- define "explo.authConfigured" -}}
+{{- if .Values.auth.existingSecret -}}
+true
+{{- else if and .Values.auth.username .Values.auth.password -}}
+true
+{{- else -}}
+false
+{{- end }}
+{{- end }}
+
+{{/*
+Config PVC claim name.
+*/}}
+{{- define "explo.configClaimName" -}}
+{{- if .Values.persistence.config.existingClaim }}
+{{- .Values.persistence.config.existingClaim }}
+{{- else }}
+{{- include "explo.fullname" . }}-config
+{{- end }}
+{{- end }}
+
+{{/*
+Media PVC claim name.
+*/}}
+{{- define "explo.mediaClaimName" -}}
+{{- if .Values.persistence.media.existingClaim }}
+{{- .Values.persistence.media.existingClaim }}
+{{- else }}
+{{- include "explo.fullname" . }}-media
+{{- end }}
+{{- end }}

--- a/charts/explo/templates/deployment.yaml
+++ b/charts/explo/templates/deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "explo.fullname" . }}
+  labels:
+    {{- include "explo.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.deploymentStrategy.type }}
+  selector:
+    matchLabels:
+      {{- include "explo.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "explo.selectorLabels" . | nindent 8 }}
+      {{- if eq (include "explo.authConfigured" .) "true" }}
+      annotations:
+        checksum/auth: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- end }}
+    spec:
+      containers:
+        - name: explo
+          image: "{{ .Values.image.repository }}:{{ include "explo.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 7288
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if eq (include "explo.authConfigured" .) "true" }}
+            - name: UI_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "explo.authSecretName" . }}
+                  key: {{ .Values.auth.usernameKey }}
+            - name: UI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "explo.authSecretName" . }}
+                  key: {{ .Values.auth.passwordKey }}
+            {{- end }}
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /api/ui/setup-status
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.persistence.config.enabled }}
+            - name: config
+              mountPath: /opt/explo/config
+            {{- end }}
+            {{- if .Values.persistence.media.enabled }}
+            - name: media
+              mountPath: {{ .Values.persistence.media.mountPath }}
+              {{- with .Values.persistence.media.subPath }}
+              subPath: {{ . }}
+              {{- end }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        {{- if .Values.persistence.config.enabled }}
+        - name: config
+          persistentVolumeClaim:
+            claimName: {{ include "explo.configClaimName" . }}
+        {{- end }}
+        {{- if .Values.persistence.media.enabled }}
+        - name: media
+          persistentVolumeClaim:
+            claimName: {{ include "explo.mediaClaimName" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/explo/templates/ingress.yaml
+++ b/charts/explo/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "explo.fullname" . }}
+  labels:
+    {{- include "explo.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "explo.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/explo/templates/pvc-config.yaml
+++ b/charts/explo/templates/pvc-config.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "explo.fullname" . }}-config
+  labels:
+    {{- include "explo.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.config.accessMode }}
+  {{- if .Values.persistence.config.storageClass }}
+  storageClassName: {{ .Values.persistence.config.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.config.size | quote }}
+{{- end }}

--- a/charts/explo/templates/pvc-media.yaml
+++ b/charts/explo/templates/pvc-media.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.media.enabled (not .Values.persistence.media.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "explo.fullname" . }}-media
+  labels:
+    {{- include "explo.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.media.accessMode }}
+  {{- if .Values.persistence.media.storageClass }}
+  storageClassName: {{ .Values.persistence.media.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.media.size | quote }}
+{{- end }}

--- a/charts/explo/templates/secret.yaml
+++ b/charts/explo/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (not .Values.auth.existingSecret) .Values.auth.username .Values.auth.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "explo.fullname" . }}-auth
+  labels:
+    {{- include "explo.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.auth.usernameKey }}: {{ .Values.auth.username | quote }}
+  {{ .Values.auth.passwordKey }}: {{ .Values.auth.password | quote }}
+{{- end }}

--- a/charts/explo/templates/service.yaml
+++ b/charts/explo/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "explo.fullname" . }}
+  labels:
+    {{- include "explo.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "explo.selectorLabels" . | nindent 4 }}

--- a/charts/explo/values.yaml
+++ b/charts/explo/values.yaml
@@ -1,0 +1,60 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/lumepart/explo
+  tag: ""
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+deploymentStrategy:
+  type: Recreate
+
+service:
+  type: ClusterIP
+  port: 7288
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []
+  tls: []
+
+env:
+  TZ: UTC
+  WEB_UI: "true"
+  WEB_ADDR: ":7288"
+  WEB_DATA_PATH: /opt/explo/config/
+  WEB_ENV_PATH: /opt/explo/config/.env
+
+auth:
+  existingSecret: ""
+  username: ""
+  password: ""
+  usernameKey: username
+  passwordKey: password
+
+persistence:
+  config:
+    enabled: true
+    existingClaim: ""
+    size: 2Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+  media:
+    enabled: true
+    existingClaim: ""
+    mountPath: /data
+    subPath: ""
+    size: 10Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+
+extraEnv: {}
+extraVolumes: []
+extraVolumeMounts: []
+
+resources: {}
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,4 +37,4 @@ services:
 
       # Uncomment for testing (runs explo right after launcing the container)
       #- EXECUTE_ON_START=false # Whether to run explo when starting the container (useful for testing)
-      #- START_FLAGS=--persist=false # if needed, set startup flags for testing
+      #- START_FLAGS=--replace-playlist=false # if needed, set startup flags for testing

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -27,7 +27,7 @@ if [ -d "$WEB_ENV_PATH" ]; then
     WEB_ENV_PATH="$WEB_ENV_PATH/.env"
     echo "[setup] Config path is a directory, using $WEB_ENV_PATH"
 fi
-WEB_UI=true WEB_ENV_PATH="$WEB_ENV_PATH" WEB_ADDR="${WEB_ADDR:-:7288}" $RUNNER ./explo &
+WEB_UI=true WEB_ENV_PATH="$WEB_ENV_PATH" WEB_ADDR="${WEB_ADDR:-:7288}" $RUNNER ./explo --config "$WEB_ENV_PATH" &
 echo "[setup] Web UI available at http://localhost:${WEB_ADDR##*:}"
 
 echo "[setup] Initializing cron jobs..."
@@ -52,7 +52,7 @@ fi
 
 # $CRON_SHCEDULE was deprecated in v0.11.0, keeping this block for backwards compatibility
 if [ -n "$CRON_SCHEDULE" ]; then
-    echo "$CRON_SCHEDULE apk add --no-cache --upgrade yt-dlp && cd /opt/explo && $RUNNER ./explo >> /proc/1/fd/1 2>&1" > /etc/crontabs/root
+    echo "$CRON_SCHEDULE apk add --no-cache --upgrade yt-dlp && cd /opt/explo && $RUNNER ./explo --config \"$_cfg\" >> /proc/1/fd/1 2>&1" > /etc/crontabs/root
     chmod 600 /etc/crontabs/root
     echo "[setup] Registered single CRON_SCHEDULE job: $CRON_SCHEDULE"
     crond -f -l 2
@@ -71,12 +71,12 @@ for var in $(env | grep "_SCHEDULE=" | cut -d= -f1); do
   fi
 
   # Default: just run explo if flags are empty
-  cmd="apk add --no-cache --upgrade yt-dlp && cd /opt/explo && $RUNNER ./explo $flags >> /proc/1/fd/1 2>&1"
+  cmd="apk add --no-cache --upgrade yt-dlp && cd /opt/explo && $RUNNER ./explo --config \"$_cfg\" $flags >> /proc/1/fd/1 2>&1"
 
   echo "$schedule $cmd" >> /etc/crontabs/root
   echo "[setup] Registered job: $job"
   echo "        Schedule: $schedule"
-  echo "        Command : ./explo $flags"
+  echo "        Command : ./explo --config $_cfg $flags"
 done
 
 chmod 600 /etc/crontabs/root
@@ -85,7 +85,7 @@ echo "[setup] Starting cron..."
 
 if [ "$EXECUTE_ON_START" = "true" ]; then
     echo "[setup] Executing startup task..."  
-    apk add --no-cache --upgrade yt-dlp && cd /opt/explo && $RUNNER ./explo $START_FLAGS
+    apk add --no-cache --upgrade yt-dlp && cd /opt/explo && $RUNNER ./explo --config "$_cfg" $START_FLAGS
     
 fi
 crond -f -l 2

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Explo Helm charts</title>
+</head>
+<body>
+  <h1>Explo Helm charts</h1>
+  <pre>
+helm repo add explo https://lumepart.github.io/Explo
+helm repo update
+helm install explo explo/explo --namespace explo --create-namespace
+  </pre>
+  <p><a href="https://github.com/LumePart/Explo/tree/dev/charts/explo">Chart documentation</a></p>
+</body>
+</html>


### PR DESCRIPTION
This project is pretty great, and I'd love to start hosting it in my kubernetes cluster. This is a first-pass at getting a minimal helm chart setup. It doesn't do HA yet, and no fancy stuff like sso, but it should be a decent initial starting point.

## Changes
* Add `charts/explo` matching compose mounts and port 7288
* Add `chart-ci.yml` to validate `charts/` on PRs
* Add `chart-release.yml` that publishes to gh-pages and uploads the chart to the existing `v*` GitHub Release after `Latest Release` completes
* Document install in `charts/explo/README.md` and links from the root README
* Scope `/explo` in `.gitignore` to the repo root so `charts/explo` is tracked
* Pass `--config "$WEB_ENV_PATH"` from `docker/start.sh` so chart config PVC persistence works for cron + UI

⚠️ One thing to note: The maintainer of this repo will need to do the following one time after/before merge:

1. For the helm chart to self-host, you'll need to enable GitHub Pages on the `gh-pages` branch. From there, the CI introduced in this pr will auto update that branch on each `v*` tag.