### PR TITLE
add PUID/PGID support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN apk add --no-cache \
 # Install ytmusicapi in the container
 RUN pip install --no-cache-dir ytmusicapi
 
+# Create user to set PUID/PGID values
+RUN useradd -ms /bin/sh explo
+
 # Set working directory
 WORKDIR /opt/explo/
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,10 @@ services:
       
       # - /path/to/cookies.txt:/opt/explo/cookies.txt # Path to optional cookies file (for yt-dlp)
     environment:
+      # User/group to run Explo as. Defaults to root (0:0) for backwards compatibility
+      # Set these to the owner UID/GID of your music folder and Explo data folder for better permission handling
+      # - PUID=1000
+      # - PGID=1000
       - TZ=UTC # Change this to the timezone set in ListenBrainz (default is UTC)
       - WEB_UI=true
       # Web UI credentials (required for login)

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,4 +1,25 @@
 #!/bin/sh
+
+PUID="${PUID:-0}"
+PGID="${PGID:-0}"
+
+if [ "$PUID" != "0" ] || [ "$PGID" != "0" ]; then
+    groupmod -o -g "$PGID" explo
+    usermod -o -u "$PUID" explo
+    RUN_USER="explo"
+    RUNNER="su-exec explo"
+else
+    echo "[setup] WARN: running as root. Consider defining PUID & PGID in docker-compose to run as a non-root user"
+    RUN_USER="root"
+    RUNNER=""
+    
+fi
+
+mkdir -p /opt/explo
+if [ "$RUN_USER" != "root" ]; then 
+  chown -R explo:explo /opt/explo
+fi
+
 echo "[setup] Starting web UI..."
 # If user incorectly mounts the config path as a directory, we'll try to automatically append it to .env inside it instead of failing.
 WEB_ENV_PATH="${WEB_ENV_PATH:-/opt/explo/.env}"
@@ -6,13 +27,10 @@ if [ -d "$WEB_ENV_PATH" ]; then
     WEB_ENV_PATH="$WEB_ENV_PATH/.env"
     echo "[setup] Config path is a directory, using $WEB_ENV_PATH"
 fi
-WEB_UI=true WEB_ENV_PATH="$WEB_ENV_PATH" WEB_ADDR="${WEB_ADDR:-:7288}" /opt/explo/explo &
+WEB_UI=true WEB_ENV_PATH="$WEB_ENV_PATH" WEB_ADDR="${WEB_ADDR:-:7288}" $RUNNER ./explo &
 echo "[setup] Web UI available at http://localhost:${WEB_ADDR##*:}"
 
 echo "[setup] Initializing cron jobs..."
-
-# Start with a clean crontab
-: > /etc/crontabs/root
 
 # Load *_SCHEDULE and *_FLAGS from .env if not already set in the environment.
 # This allows the web UI to configure schedules by writing to the .env file.
@@ -34,7 +52,7 @@ fi
 
 # $CRON_SHCEDULE was deprecated in v0.11.0, keeping this block for backwards compatibility
 if [ -n "$CRON_SCHEDULE" ]; then
-    echo "$CRON_SCHEDULE apk add --upgrade yt-dlp && cd /opt/explo && ./explo >> /proc/1/fd/1 2>&1" > /etc/crontabs/root
+    echo "$CRON_SCHEDULE apk add --no-cache --upgrade yt-dlp && cd /opt/explo && $RUNNER ./explo >> /proc/1/fd/1 2>&1" > /etc/crontabs/root
     chmod 600 /etc/crontabs/root
     echo "[setup] Registered single CRON_SCHEDULE job: $CRON_SCHEDULE"
     crond -f -l 2
@@ -53,7 +71,7 @@ for var in $(env | grep "_SCHEDULE=" | cut -d= -f1); do
   fi
 
   # Default: just run explo if flags are empty
-  cmd="apk add --upgrade yt-dlp && cd /opt/explo && ./explo $flags >> /proc/1/fd/1 2>&1"
+  cmd="apk add --no-cache --upgrade yt-dlp && cd /opt/explo && $RUNNER ./explo $flags >> /proc/1/fd/1 2>&1"
 
   echo "$schedule $cmd" >> /etc/crontabs/root
   echo "[setup] Registered job: $job"
@@ -67,7 +85,7 @@ echo "[setup] Starting cron..."
 
 if [ "$EXECUTE_ON_START" = "true" ]; then
     echo "[setup] Executing startup task..."  
-    apk add --upgrade yt-dlp && cd /opt/explo && ./explo $START_FLAGS
+    apk add --no-cache --upgrade yt-dlp && cd /opt/explo && $RUNNER ./explo $START_FLAGS
     
 fi
 crond -f -l 2


### PR DESCRIPTION
Add `PUID`/`PGID` support for running Explo as a non-root user in a container.

The default remains root (`0:0`) to preserve backwards compatibility with existing setups. Users can define custom UID/GID to improve permission handling in mounted folders.