### PR TITLE
Adds auth bypass request from #134

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts run inside Linux containers. On a Windows checkout with
+# core.autocrlf=true they would otherwise get CRLF endings, and a CRLF shebang
+# makes the image fail at startup with:
+#   exec /start.sh: no such file or directory
+*.sh text eol=lf

--- a/src/web/backend/auth/auth.go
+++ b/src/web/backend/auth/auth.go
@@ -13,10 +13,20 @@ import (
 type AuthStore struct {
 	Username string
 	Hash string
+	Disabled bool // true when no credentials are configured; all routes become public
 	sessionManager *SessionManager
 }
 
 func NewAuthStore(user, password string, sessionManager *SessionManager) *AuthStore{
+	// No credentials configured at all: run the UI unauthenticated instead of
+	// showing a login screen that accepts empty input anyway.
+	if user == "" && password == "" {
+		return &AuthStore{
+			Disabled: true,
+			sessionManager: sessionManager,
+		}
+	}
+
 	hashPass, err := hashPassword(password)
 	if err != nil {
 		panic("failed to hash password")
@@ -38,6 +48,10 @@ func (a *AuthStore) CompareCreds(formUser, formPass string) bool {
 }
 
 func (a *AuthStore) RequireAuth(next http.Handler) http.Handler {
+	if a.Disabled {
+		return next
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sess := a.sessionManager.GetSession(r)
 

--- a/src/web/backend/auth/handlers.go
+++ b/src/web/backend/auth/handlers.go
@@ -7,19 +7,41 @@ import (
 )
 
 func (a *AuthStore) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
+	if a.Disabled {
+		writeAuthStatus(w, true, true)
+		return
+	}
+
 	sess := a.sessionManager.GetSession(r)
 	auth, _ := sess.Get("authenticated").(bool)
 	if !auth {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+	writeAuthStatus(w, true, false)
+}
+
+func writeAuthStatus(w http.ResponseWriter, authenticated, disabled bool) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]bool{
+		"authenticated": authenticated,
+		"auth_disabled": disabled,
+	}); err != nil {
+		slog.Error("failed encoding auth status to http", "msg", err.Error())
+	}
 }
 
 func (a *AuthStore) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		err := http.StatusMethodNotAllowed
 		http.Error(w, "Invalid request method", err)
+		return
+	}
+
+	// Nothing to authenticate against. Accept, so a cached frontend that still
+	// renders the login form does not get a confusing 401 from the empty hash.
+	if a.Disabled {
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 
@@ -49,6 +71,11 @@ func (a *AuthStore) HandleLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *AuthStore) HandleLogout(w http.ResponseWriter, r *http.Request) {
+	if a.Disabled {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	sess := a.sessionManager.GetSession(r)
 	sess.Delete("authenticated")
 	sess.Delete("username")

--- a/src/web/backend/server.go
+++ b/src/web/backend/server.go
@@ -89,6 +89,9 @@ func (s *Server) Start() error {
 	if _, err := os.Stat(coversDir); os.IsNotExist(err) {
 		s.customPlaylist.PrefetchCovers()
 	}
+	if s.authStore.Disabled {
+		slog.Warn("web UI authentication is DISABLED - UI_USERNAME and UI_PASSWORD are not set; anyone who can reach this address has full control over Explo")
+	}
 	slog.Info("Explo web UI started", "addr", s.server.Addr)
 	go checkForUpdate()
 	return s.server.ListenAndServe()

--- a/src/web/frontend/src/App.jsx
+++ b/src/web/frontend/src/App.jsx
@@ -12,14 +12,16 @@ export default function App() {
   const [bgUrl, setBgUrl] = useState(null)
   const [bgLoaded, setBgLoaded] = useState(false)
   const [fadingOut, setFadingOut] = useState(false)
+  const [authDisabled, setAuthDisabled] = useState(false)
 
   useEffect(() => {
     Promise.all([
       checkAuth(),
       fetchSetupStatus(),
-    ]).then(([authed, status]) => {
+    ]).then(([{ authenticated, authDisabled }, status]) => {
       setIsFirstTime(status ? !status.wizard_complete : false)
-      if (authed) {
+      setAuthDisabled(authDisabled)
+      if (authenticated) {
         handleLoginSuccess({ fromLogin: false })
       } else {
         setView('login')
@@ -83,6 +85,7 @@ export default function App() {
 
   return (
     <Settings
+      authDisabled={authDisabled}
       onWizard={() => setView('wizard')}
       onLogout={() => logout().then(() => setView('login'))}
     />

--- a/src/web/frontend/src/components/Settings.jsx
+++ b/src/web/frontend/src/components/Settings.jsx
@@ -957,7 +957,7 @@ function LogsSection() {
 // Module-level cache so the picked cover survives component remounts.
 let _bgCoverCache = null
 
-export default function Settings({ onWizard, onLogout }) {
+export default function Settings({ authDisabled, onWizard, onLogout }) {
   const [activeTab, setActiveTab] = useState('run')
   const [bgCover, setBgCover] = useState(_bgCoverCache)
 
@@ -1012,12 +1012,21 @@ export default function Settings({ onWizard, onLogout }) {
               <button className={tabBtnCls(activeTab === 'config')} onClick={() => setActiveTab('config')}>Settings</button>
               <button className={tabBtnCls(activeTab === 'logs')} onClick={() => setActiveTab('logs')}>Logs</button>
             </nav>
-            <button
-              onClick={onLogout}
-              className="pb-2 text-[12px] text-muted hover:text-white transition-colors cursor-pointer bg-transparent border-none"
-            >
-              Sign out
-            </button>
+            {authDisabled ? (
+              <span
+                title="UI_USERNAME and UI_PASSWORD are not set, so the web UI is open to anyone who can reach it."
+                className="pb-2 text-[12px] text-muted/70 cursor-default select-none"
+              >
+                Auth disabled
+              </span>
+            ) : (
+              <button
+                onClick={onLogout}
+                className="pb-2 text-[12px] text-muted hover:text-white transition-colors cursor-pointer bg-transparent border-none"
+              >
+                Sign out
+              </button>
+            )}
           </header>
 
           {activeTab === 'run' && <HomeSection />}

--- a/src/web/frontend/src/lib/api.js
+++ b/src/web/frontend/src/lib/api.js
@@ -28,7 +28,9 @@ async function apiFetch(url, options = {}) {
 
 export async function checkAuth() {
   const res = await fetch('/api/ui/auth/status', { credentials: 'include' })
-  return res.ok
+  // Older builds return an empty body, so tolerate a failed parse.
+  const data = await res.json().catch(() => ({}))
+  return { authenticated: res.ok, authDisabled: !!data.auth_disabled }
 }
 
 export async function login(username, password) {


### PR DESCRIPTION
When `UI_USERNAME` and `UI_PASSWORD` are both unset, weskip the login screen entirely rather than rendering a form that already accepted empty input, so single-admin instances on trusted networks land straight in the UI (refs #134). 

Behavior is unchanged when credentials are configured, CSRF stays enforced either way, and the unauthenticated state is never silent: the server logs a warning at startup and the header shows an "Auth disabled" chip in place of "Sign out". The Auth disabled is just a visuall artifact to keep a consistent header styling but honestly probably unnecessary. 

Smaller change is another commit to force LF via gitattributes if you're a degenerate like me deving on a windows machine and have auto crlf on. shouldnt impact nix/mac devs