### PR TITLE
Adds suffix removal for Apple Music playlist imports

### DIFF
--- a/src/web/backend/defs/defs.go
+++ b/src/web/backend/defs/defs.go
@@ -3,8 +3,8 @@ package defs
 import (
 	"regexp"
 )
-// place for confs/variables in use by the UI or backend
 
+// place for confs/variables in use by the UI or backend
 
 // Custom playlist regex validation
 var CustomIDRe = regexp.MustCompile(`^custom-[a-z0-9]+$`)
@@ -181,5 +181,5 @@ var AllConfigKeys = []string{
 	"DOWNLOAD_DIR", "USE_SUBDIRECTORY", "PATH_TEMPLATE", "ENRICH_TRACK_METADATA",
 	"DOWNLOAD_SERVICES", "YOUTUBE_API_KEY", "TRACK_EXTENSION", "FILTER_LIST",
 	"SLSKD_URL", "SLSKD_API_KEY",
-	"WIZARD_COMPLETE", "MIGRATE_DOWNLOADS", "EXTENSIONS", "LISTENBRAINZ_USER_TOKEN",
+	"WIZARD_COMPLETE", "MIGRATE_DOWNLOADS", "EXTENSIONS", "LISTENBRAINZ_USER_TOKEN", "SUFFIX_REMOVAL",
 }

--- a/src/web/backend/playlist/apple_music.go
+++ b/src/web/backend/playlist/apple_music.go
@@ -7,9 +7,12 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"regexp"
 
 	"golang.org/x/net/html"
 )
+
+var albumSuffixRe = regexp.MustCompile(`(?i)\s*[-–]\s*(single|ep)\s*$`)
 
 // appleServerData mirrors the top-level shape of the
 // <script id="serialized-server-data"> JSON blob on Apple Music pages.
@@ -148,7 +151,11 @@ func extractServerData(htmlStr string) (string, string, []PlaylistTrack, error) 
 			for _, item := range sec.Items {
 				album := ""
 				if len(item.TertiaryLinks) > 0 {
-					album = item.TertiaryLinks[0].Title
+					album = albumSuffixRe.ReplaceAllString(item.TertiaryLinks[0].Title, "")
+					// if RemoveAMModifiers {
+					// 	var re := regexp.MustCompile(`(?i)\s*[-–]\s*(single|ep)\s*$`)
+					// 	album := re.ReplaceAllString(album, "")
+					// }
 				}
 				coverURL := ""
 				if item.Artwork != nil {

--- a/src/web/backend/playlist/apple_music.go
+++ b/src/web/backend/playlist/apple_music.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"strings"
 	"regexp"
+	"strings"
 
 	"golang.org/x/net/html"
 )
@@ -56,7 +56,7 @@ func resolveArtworkURL(tpl string) string {
 // fetchAppleMusicPlaylist scrapes a public Apple Music playlist page and extracts
 // track info from the embedded server data.
 // Returns (playlistName, artworkURL, tracks, error) where tracks are [title, artist, album, coverURL].
-func fetchAppleMusicPlaylist(pageURL string) (string, string, []PlaylistTrack, error) {
+func fetchAppleMusicPlaylist(pageURL string, enabled bool) (string, string, []PlaylistTrack, error) {
 	req, err := http.NewRequest("GET", pageURL, nil)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("apple music: invalid URL: %w", err)
@@ -88,7 +88,7 @@ func fetchAppleMusicPlaylist(pageURL string) (string, string, []PlaylistTrack, e
 	htmlStr := string(body)
 
 	// Parse the serialized-server-data for everything: playlist name, artwork, tracks.
-	playlistName, artworkURL, tracks, err := extractServerData(htmlStr)
+	playlistName, artworkURL, tracks, err := extractServerData(htmlStr, enabled)
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -107,7 +107,7 @@ func fetchAppleMusicPlaylist(pageURL string) (string, string, []PlaylistTrack, e
 
 // extractServerData parses the <script id="serialized-server-data"> blob for
 // the playlist name, playlist artwork URL (from the header section), and tracks with artwork.
-func extractServerData(htmlStr string) (string, string, []PlaylistTrack, error) {
+func extractServerData(htmlStr string, enabled bool) (string, string, []PlaylistTrack, error) {
 	scripts := extractScriptByID(htmlStr, "serialized-server-data")
 	if len(scripts) == 0 {
 		return "", "", nil, fmt.Errorf("apple music: no serialized-server-data found in page")
@@ -151,11 +151,7 @@ func extractServerData(htmlStr string) (string, string, []PlaylistTrack, error) 
 			for _, item := range sec.Items {
 				album := ""
 				if len(item.TertiaryLinks) > 0 {
-					album = albumSuffixRe.ReplaceAllString(item.TertiaryLinks[0].Title, "")
-					// if RemoveAMModifiers {
-					// 	var re := regexp.MustCompile(`(?i)\s*[-–]\s*(single|ep)\s*$`)
-					// 	album := re.ReplaceAllString(album, "")
-					// }
+					album = suffixRegexRemoval(item.TertiaryLinks[0].Title, enabled)
 				}
 				coverURL := ""
 				if item.Artwork != nil {
@@ -176,6 +172,15 @@ func extractServerData(htmlStr string) (string, string, []PlaylistTrack, error) 
 		return "", "", nil, fmt.Errorf("apple music: no track data found in server data")
 	}
 	return playlistName, artworkURL, tracks, nil
+}
+
+// suffixRegexRemoval checks .env and removes the suffixes created my Apple Music using regex.
+func suffixRegexRemoval(albumName string, enabled bool) string {
+	if enabled {
+		var newAlbumName = albumSuffixRe.ReplaceAllString(albumName, "")
+		return newAlbumName
+	}
+	return albumName
 }
 
 // extractPlaylistNameFromJSONLD pulls the playlist title from the JSON-LD MusicPlaylist block.

--- a/src/web/backend/playlist/custom_playlists.go
+++ b/src/web/backend/playlist/custom_playlists.go
@@ -12,7 +12,6 @@ import (
 
 	"explo/src/discovery"
 	"explo/src/util"
-
 )
 
 // CustomPlaylist holds the metadata for a user-imported playlist.
@@ -121,10 +120,10 @@ type FetchResult struct {
 
 // fetchCustomPlaylistTracks dispatches to the appropriate source fetcher.
 // This is the single point where source-specific logic lives for fetching.
-func fetchCustomPlaylistTracks(p CustomPlaylist) (FetchResult, error) {
+func fetchCustomPlaylistTracks(p CustomPlaylist, enabled bool) (FetchResult, error) {
 	switch p.Source {
 	case "apple_music":
-		name, art, tracks, err := fetchAppleMusicPlaylist(p.SourceURL)
+		name, art, tracks, err := fetchAppleMusicPlaylist(p.SourceURL, enabled)
 		return FetchResult{name, art, tracks}, err
 	case "spotify":
 		name, art, tracks, err := fetchSpotifyPlaylist(p.SourceURL)

--- a/src/web/backend/playlist/handlers.go
+++ b/src/web/backend/playlist/handlers.go
@@ -2,22 +2,21 @@ package playlist
 
 import (
 	"encoding/json"
-	"net/http"
 	"fmt"
-	"os"
 	"log/slog"
-	"path/filepath"
 	"math/rand/v2"
+	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"explo/src/util"
-	"explo/src/web/backend/defs"
 	"explo/src/web"
+	"explo/src/web/backend/defs"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
-
 
 // handleGetCustomPlaylists returns all saved custom playlists with a track_count
 // derived from their cache file (if present) and the current sync schedule from .env.
@@ -85,7 +84,19 @@ func (p *Playlist) HandleImportCustomPlaylist(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result, err := fetchCustomPlaylistTracks(CustomPlaylist{Source: body.Source, SourceURL: body.URL})
+	// Read .env
+	var envValues map[string]string
+	var enabled = false
+	if data, err := os.ReadFile(p.cfg.WebEnvPath); err == nil {
+		envValues = p.settings.ParseEnvText(string(data))
+	} else {
+		envValues = map[string]string{}
+	}
+	if envValues["SUFFIX_REMOVAL"] == "true" {
+		enabled = true
+	}
+
+	result, err := fetchCustomPlaylistTracks(CustomPlaylist{Source: body.Source, SourceURL: body.URL}, enabled)
 	if err != nil {
 		slog.Error("custom-playlists: fetch failed", "source", body.Source, "err", err)
 		http.Error(w, "failed to fetch playlist: "+err.Error(), http.StatusBadGateway)

--- a/src/web/backend/playlist/handlers.go
+++ b/src/web/backend/playlist/handlers.go
@@ -229,10 +229,21 @@ func (p *Playlist) HandleRefreshCustomPlaylist(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	var envValues map[string]string
+	var AMSuffixRe = false
+	if data, err := os.ReadFile(p.cfg.WebEnvPath); err == nil {
+		envValues = p.settings.ParseEnvText(string(data))
+	} else {
+		envValues = map[string]string{}
+	}
+	if envValues["SUFFIX_REMOVAL"] == "true" {
+		AMSuffixRe = true
+	}
+
 	plist := playlists[idx]
 	slog.Info("custom-playlists: manual refresh", "id", id, "source", plist.Source)
 
-	result, err := fetchCustomPlaylistTracks(plist)
+	result, err := fetchCustomPlaylistTracks(plist, AMSuffixRe)
 	if err != nil {
 		slog.Error("custom-playlists: refresh fetch failed", "id", id, "err", err)
 		http.Error(w, "failed to fetch playlist: "+err.Error(), http.StatusBadGateway)

--- a/src/web/backend/playlist/jobs.go
+++ b/src/web/backend/playlist/jobs.go
@@ -1,11 +1,11 @@
 package playlist
 
 import (
+	"explo/src/util"
+	"explo/src/web/backend/jobs"
 	"log/slog"
 	"os"
 	"time"
-	"explo/src/util"
-	"explo/src/web/backend/jobs"
 
 	"github.com/go-co-op/gocron/v2"
 )
@@ -19,10 +19,14 @@ func (p *Playlist) RegisterCustomPlaylistRefresh(j *jobs.Jobs) error {
 	}
 
 	var envValues map[string]string
+	var AMSuffixRe = false
 	if data, err := os.ReadFile(p.cfg.WebEnvPath); err == nil {
 		envValues = p.settings.ParseEnvText(string(data))
 	} else {
 		envValues = map[string]string{}
+	}
+	if envValues["SUFFIX_REMOVAL"] == "true" {
+		AMSuffixRe = true
 	}
 
 	for _, plist := range playlists {
@@ -46,7 +50,7 @@ func (p *Playlist) RegisterCustomPlaylistRefresh(j *jobs.Jobs) error {
 					return
 				}
 				slog.Info("custom-playlists: refreshing", "id", plist.ID, "name", plist.Name, "source", plist.Source)
-				result, err := fetchCustomPlaylistTracks(plist)
+				result, err := fetchCustomPlaylistTracks(plist, AMSuffixRe)
 				if err != nil {
 					slog.Warn("custom-playlists: refresh fetch failed", "id", plist.ID, "err", err)
 					return

--- a/src/web/backend/routes.go
+++ b/src/web/backend/routes.go
@@ -1,11 +1,11 @@
 package backend
 
 import (
+	"io/fs"
 	"log/slog"
 	"net/http"
-	"strings"
-	"io/fs"
 	"path/filepath"
+	"strings"
 )
 
 func (s *Server) registerRoutes() {
@@ -55,6 +55,7 @@ func (s *Server) registerSettingRoutes() {
 	s.mux.Handle("POST /api/ui/config/enrich-metadata", s.auth(s.settings.HandleSaveEnrichMetadata))
 	s.mux.Handle("POST /api/ui/config/replace-playlist", s.auth(s.settings.HandleSaveReplacePlaylist))
 	s.mux.Handle("POST /api/ui/config/clean-downloads", s.auth(s.settings.HandleSaveCleanDownloads))
+	s.mux.Handle("POST /api/ui/config/suffix-removal", s.auth(s.settings.HandleSaveSuffixRemoval))
 
 	// Path template presets: GET list, POST add; DELETE per name under prefix
 	s.mux.Handle("api/ui/path-templates", s.auth(s.settings.HandlePathTemplates))

--- a/src/web/backend/settings/handlers.go
+++ b/src/web/backend/settings/handlers.go
@@ -372,7 +372,7 @@ func (s *Settings) HandleWizardStep1(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleSaveSuffixRemoval
+// handleSaveSuffixRemoval handles toggling our Suffix Removal for Apple Music.
 func (s *Settings) HandleSaveSuffixRemoval(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/src/web/backend/settings/handlers.go
+++ b/src/web/backend/settings/handlers.go
@@ -372,6 +372,32 @@ func (s *Settings) HandleWizardStep1(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// handleSaveSuffixRemoval
+func (s *Settings) HandleSaveSuffixRemoval(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	val := "false"
+	if body.Enabled {
+		val = "true"
+	}
+	if err := s.UpdateEnvKeys(map[string]string{"SUFFIX_REMOVAL": val}, web.SampleEnv); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 // handleWizardStep2 saves media system configuration.
 func (s *Settings) HandleWizardStep2(w http.ResponseWriter, r *http.Request) {
 	var body struct {

--- a/src/web/backend/settings/handlers.go
+++ b/src/web/backend/settings/handlers.go
@@ -372,32 +372,6 @@ func (s *Settings) HandleWizardStep1(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleSaveSuffixRemoval handles toggling our Suffix Removal for Apple Music.
-func (s *Settings) HandleSaveSuffixRemoval(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	var body struct {
-		Enabled bool `json:"enabled"`
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	val := "false"
-	if body.Enabled {
-		val = "true"
-	}
-	if err := s.UpdateEnvKeys(map[string]string{"SUFFIX_REMOVAL": val}, web.SampleEnv); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.WriteHeader(http.StatusOK)
-}
-
 // handleWizardStep2 saves media system configuration.
 func (s *Settings) HandleWizardStep2(w http.ResponseWriter, r *http.Request) {
 	var body struct {
@@ -581,6 +555,32 @@ func (s *Settings) HandleDeletePathTemplate(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := savePathTemplates(cfgDir, filtered); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleSaveSuffixRemoval handles toggling Suffix Removal for Apple Music.
+func (s *Settings) HandleSaveSuffixRemoval(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	val := "false"
+	if body.Enabled {
+		val = "true"
+	}
+	if err := s.UpdateEnvKeys(map[string]string{"SUFFIX_REMOVAL": val}, web.SampleEnv); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/src/web/frontend/src/components/Settings.jsx
+++ b/src/web/frontend/src/components/Settings.jsx
@@ -15,7 +15,7 @@ import {
   fetchConfig, fetchConfigRaw, saveConfig, resetConfig,
   saveSchedule, startRun, stopRun, fetchRunStatus, fetchLogs,
   fetchCustomPlaylists, deleteCustomPlaylist, savePathTemplate, saveEnrichMetadata,
-  saveReplacePlaylist, saveCleanDownloads,
+  saveReplacePlaylist, saveCleanDownloads, saveSuffixRemoval,
   fetchPathTemplatePresets, addPathTemplatePreset, deletePathTemplatePreset,
 } from '../lib/api'
 import { parseSlogLine, cronToFields, highlightEnv } from '../lib/utils'
@@ -525,6 +525,7 @@ function DownloadPathSection() {
   const [enrichEnabled, setEnrichEnabled] = useState(false)
   const [cleanDownloads, setCleanDownloads] = useState(false)
   const [templateEnabled, setTemplateEnabled] = useState(false)
+  const [suffixRemoval, setSuffixRemoval] = useState(false)
 
   useEffect(() => {
     Promise.all([
@@ -581,6 +582,12 @@ function DownloadPathSection() {
       setTemplateEnabled(true)
       if (selectedIdx === null) setSelectedIdx(0)
     }
+  }
+
+  const handleSuffixToggle = async () => {
+    const next = !suffixRemoval
+    setSuffixRemoval(next)
+    try { await saveSuffixRemoval(next) } catch { setSuffixRemoval(!next) }
   }
 
   useEffect(() => {
@@ -688,6 +695,22 @@ function DownloadPathSection() {
         </button>
       </div>
 
+      {/* Remove "- Single/ - EP from album names for Apple Music"*/}
+      <div className="flex items-start justify-between mt-3 mb-1 gap-4">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[13px] text-white">Remove suffixes from album names from Apple Music</span>
+          <span className="text-[13px] text-muted">Removes the additional suffixes (e.g " - EP", " - Single") Apple Music generates when importing playlists.</span>
+        </div>
+        <button
+          role="switch"
+          aria-checked={suffixRemoval}
+          onClick={handleSuffixToggle}
+          className={`relative inline-flex h-[22px] w-10 shrink-0 cursor-pointer rounded-full transition-colors duration-200 ${suffixRemoval ? 'bg-accent' : 'bg-[#383838]'}`}
+          >
+            <span className={`inline-block h-[18px] w-[18px] my-[2px] rounded-full bg-white shadow transition-transform duration-200 ${suffixRemoval ? 'translate-x-[20px]' : 'translate-x-[2px]'}`} />
+          </button>
+      </div>
+
       {templateEnabled && (<>
       {/* Current / pending path readout */}
       <div className="flex items-baseline gap-2.5 overflow-x-auto py-1 mt-6">
@@ -698,6 +721,9 @@ function DownloadPathSection() {
           <PathLine template={previewTemplate} />
         </div>
       </div>
+
+      
+      
 
       {/* Profile card grid */}
       <div className="grid grid-cols-1 min-[520px]:grid-cols-2 min-[720px]:grid-cols-4 gap-3 mt-2">

--- a/src/web/frontend/src/components/Settings.jsx
+++ b/src/web/frontend/src/components/Settings.jsx
@@ -696,7 +696,7 @@ function DownloadPathSection() {
         </button>
       </div>
 
-      {/* Remove "- Single/ - EP from album names for Apple Music"*/}
+      {/* Remove suffixes from album names for Apple Music*/}
       <div className="flex items-start justify-between mt-3 mb-1 gap-4">
         <div className="flex flex-col gap-0.5">
           <span className="text-[13px] text-white">Remove suffixes from album names from Apple Music</span>

--- a/src/web/frontend/src/components/Settings.jsx
+++ b/src/web/frontend/src/components/Settings.jsx
@@ -536,6 +536,7 @@ function DownloadPathSection() {
         ...SEED_PRESETS.map(p => ({ ...p, seed: true })),
         ...jsonPresets,
       ]
+      setSuffixRemoval(values.SUFFIX_REMOVAL === 'true')
       setEnrichEnabled(values.ENRICH_TRACK_METADATA === 'true')
       const anyFlags = values.WEEKLY_EXPLORATION_FLAGS || values.WEEKLY_JAMS_FLAGS || values.DAILY_JAMS_FLAGS || values.ON_REPEAT_FLAGS || ''
       setCleanDownloads(anyFlags.includes('--clean-downloads'))

--- a/src/web/frontend/src/lib/api.js
+++ b/src/web/frontend/src/lib/api.js
@@ -248,6 +248,15 @@ export async function saveCleanDownloads(enabled) {
   if (!res.ok) throw new Error(await res.text())
 }
 
+export async function saveSuffixRemoval(enabled) {
+  const res = await apiFetch('/api/ui/config/suffix-removal', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enabled }),
+  })
+  if (!res.ok) throw new Error(await res.text())
+}
+
 export async function fetchBackgroundArt() {
   try {
     const res = await fetch('/api/ui/background-art')


### PR DESCRIPTION
Hello!

I just found out about this service yesterday and was really interested in getting it set up! I currently use Apple Music and a lot of my playlists are on there, and I remembered that Apple Music will append " - Single / - EP" to albums that aren't full length albums, and a lot of last.fm scrobbling services either have an option to circumvent this or just entirely break scrobbling. I mention this because whenever you import an Apple Music playlist, the metadata is ripped straight from the site and thus, a self-hosted music library (in my case, Jellyfin) will display those album names with the suffixes appended at the end. Because of how Jellyfin handles metadata, this causes a lot of metadata to be skipped and mess up your music library.

With this, I decided to create a function and a toggle to use regular expressions to remove these suffixes from album names before being imported into your music library, allowing for a cleaner library. This optional feature can be toggled in the Settings tab in the frontend but is also an environment variable in the .env file! With that in mind, this is my first time writing in Go and JavaScript, so there may be some things incorrect and I would love to work through any potential issues that may arise.

Thank you for this incredible product and I hope that my contributions make it just a tad bit better!  