### PR TITLE
Fix cover art embedded as a plain video stream

### DIFF
--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -236,6 +236,8 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 			}
 		}
 		opts = ffmpeg.KwArgs{
+			"c:v": "copy",
+			"disposition:v:0": "attached_pic",
 			"metadata": metadata,
 			"loglevel": "error",
 		}

--- a/src/downloader/youtube.go
+++ b/src/downloader/youtube.go
@@ -236,10 +236,11 @@ func saveVideo(c Youtube, track models.Track, stream *goutubedl.DownloadResult) 
 			}
 		}
 		opts = ffmpeg.KwArgs{
-			"c:v": "copy",
+			"c:v":            "mjpeg",
 			"disposition:v:0": "attached_pic",
-			"metadata": metadata,
-			"loglevel": "error",
+			"metadata:s:v":   []string{"title=Album cover", "comment=Cover (front)"},
+			"metadata":       metadata,
+			"loglevel":       "error",
 		}
 	} else {
 		opts = ffmpeg.KwArgs{


### PR DESCRIPTION
This fixes embedded cover art for non-MP3 output such as M4A. ffmpeg currently re-encodes the image as a normal video stream. Copying it and setting `attached_pic` makes players and library scanners recognize it as album art.

Verified with ffprobe on M4A output:

```text
before: codec_name=h264   attached_pic=0
after:  codec_name=mjpeg  attached_pic=1
```