### PR TITLE
refactor: skip music system library refresh when no new tracks are downloaded

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -190,7 +190,7 @@ func (c *Client) CheckTracks(tracks []*models.Track) error {
 	return nil
 }
 
-func (c *Client) CreatePlaylist(tracks []*models.Track) error {
+func (c *Client) RefreshLibrary() error {
 	if c.System == "" {
 		return fmt.Errorf("could not get music system")
 	}
@@ -203,6 +203,13 @@ func (c *Client) CreatePlaylist(tracks []*models.Track) error {
 		slog.Debug("could not check library refresh state, either the client doesn't support it or threw an error")
 		slog.Debug("falling back on SLEEP env variable")
 		time.Sleep(time.Duration(c.Cfg.Sleep) * time.Minute)
+	}
+	return nil
+}
+
+func (c *Client) CreatePlaylist(tracks []*models.Track) error {
+	if c.System == "" {
+		return fmt.Errorf("could not get music system")
 	}
 
 	if err := c.API.SearchSongs(tracks); err != nil { // search newly added songs

--- a/src/downloader/downloader.go
+++ b/src/downloader/downloader.go
@@ -54,15 +54,17 @@ func NewDownloader(cfg *cfg.DownloadConfig, httpClient *util.HttpClient, filterL
 		Downloaders: downloader}, nil
 }
 
-func (c *DownloadClient) StartDownload(tracks *[]*models.Track) {
+func (c *DownloadClient) StartDownload(tracks *[]*models.Track) int {
 	if c.Cfg.ExcludeLocal { // remove locally found tracks, so they can't be added to playlist
 		filterLocalTracks(tracks, true)
 	}
 
+	var newDownloads atomic.Int32
+
 	if c.needsDownloadDir() {
 		if err := os.MkdirAll(c.Cfg.DownloadDir, 0755); err != nil {
 			slog.Error(err.Error())
-			return
+			return 0
 		}
 	}
 
@@ -100,13 +102,17 @@ func (c *DownloadClient) StartDownload(tracks *[]*models.Track) {
 					return nil
 				}
 
+				if track.Present {
+					newDownloads.Add(1)
+				}
+
 				return nil
 			})
 		}
 
 		if err := g.Wait(); err != nil {
 			slog.Warn(err.Error())
-			return
+			return int(newDownloads.Load())
 		}
 
 		if m, ok := d.(Monitor); ok {
@@ -117,6 +123,7 @@ func (c *DownloadClient) StartDownload(tracks *[]*models.Track) {
 	}
 
 	filterLocalTracks(tracks, false)
+	return int(newDownloads.Load())
 }
 func (c *DownloadClient) needsDownloadDir() bool {
 	for _, svc := range c.Cfg.Services {

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -216,7 +216,14 @@ func main() {
 	}
 
 	if cfg.Flags.DownloadMode != "skip" {
-		downloader.StartDownload(&tracks)
+		newDownloads := downloader.StartDownload(&tracks)
+		if newDownloads > 0 {
+			if err := client.RefreshLibrary(); err != nil {
+				slog.Warn(err.Error())
+			}
+		} else {
+			slog.Info("no new tracks downloaded, skipping library refresh", "system", cfg.System)
+		}
 		if len(tracks) == 0 {
 			slog.Error("couldn't download any tracks", "notify", true)
 			os.Exit(1)


### PR DESCRIPTION
### Summary

Currently, Explo calls `RefreshLibrary()` unconditionally inside `CreatePlaylist()`. For clients that don't report active refresh state (such as Subsonic/Navidrome), this triggers a full library scan and falls back on `SLEEP` (e.g. 1 minute wait) even when **0 new tracks** were downloaded.

### Solution

1. **Uncouple `RefreshLibrary()` from `CreatePlaylist()`**: Remove `c.API.RefreshLibrary()` from inside `CreatePlaylist()` in `src/client/client.go`.
2. **Track Download Count**: Return the count of newly downloaded tracks from `downloader.StartDownload(&tracks)`.
3. **Conditional Scan in `main.go`**: Call `client.RefreshLibrary()` in `main.go` **only when `newDownloads > 0`**.

This keeps `CreatePlaylist()` focused on updating playlist tracklists and avoids redundant library scans or sleep delays when all songs already exist locally.