### PR TITLE
fix(subsonic): update existing playlist in-place by passing playlistId

### DIFF
--- a/src/client/subsonic.go
+++ b/src/client/subsonic.go
@@ -240,12 +240,19 @@ func (c *Subsonic) CheckRefreshState() bool {
 }
 
 func (c *Subsonic) CreatePlaylist(tracks []*models.Track) error {
+	_ = c.SearchPlaylist()
+
 	var trackIDs strings.Builder
 	for _, track := range tracks { // build songID parameters
 		fmt.Fprintf(&trackIDs, "&songId=%s", track.ID)
 	}
 
-	reqParam := fmt.Sprintf("createPlaylist?name=%s%s&f=json", url.QueryEscape(c.Cfg.PlaylistName), trackIDs.String())
+	var reqParam string
+	if c.Cfg.PlaylistID != "" {
+		reqParam = fmt.Sprintf("createPlaylist?playlistId=%s&name=%s%s&f=json", url.QueryEscape(c.Cfg.PlaylistID), url.QueryEscape(c.Cfg.PlaylistName), trackIDs.String())
+	} else {
+		reqParam = fmt.Sprintf("createPlaylist?name=%s%s&f=json", url.QueryEscape(c.Cfg.PlaylistName), trackIDs.String())
+	}
 
 	body, err := c.subsonicRequest(reqParam)
 	if err != nil {

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -200,7 +200,7 @@ func main() {
 		slog.Error(err.Error(), "notify", true)
 		os.Exit(1)
 	}
-	if cfg.ReplacePlaylist {
+	if cfg.ReplacePlaylist && cfg.System != "subsonic" {
 		err := client.DeletePlaylist()
 		if err != nil {
 			slog.Warn(err.Error(), "notify", true)


### PR DESCRIPTION
### Problem

In the Subsonic REST API specification, `createPlaylist` is the standard endpoint for both creating and replacing playlist tracklists:
- Without `playlistId`, the server creates a new playlist entity.
- With `playlistId`, the server updates the existing playlist in-place.

Previously, Explo did not pass `playlistId` in `CreatePlaylist()` and instead invoked `DeletePlaylist()` prior to creation. This destructively deleted the playlist entity from the database on every sync, assigning a new playlist ID and breaking client applications (e.g. Symfonium, DSub) that track playlist IDs for favorites and delta sync.

### Solution

1. In `CreatePlaylist()`, look up the existing playlist ID via `SearchPlaylist()`. If found, pass `createPlaylist?playlistId=...&name=...` to update the playlist tracklist in-place without altering its ID.
2. In `main.go`, skip pre-deleting the playlist for `subsonic` (`if cfg.ReplacePlaylist && cfg.System != "subsonic"`), keeping `DeletePlaylist()` available on the Subsonic client interface.