### PR TITLE
Fix "Save each run as new playlist" toggle never saving

### DIFF
--- a/src/web/frontend/src/components/Settings.jsx
+++ b/src/web/frontend/src/components/Settings.jsx
@@ -320,7 +320,7 @@ function HomeSection() {
       onReplaceToggle: () => {
         const next = !(replacePlaylists[id] ?? true)
         setReplacePlaylists(prev => ({ ...prev, [id]: next }))
-        saveReplacePlaylist(id, next).catch(() =>
+        saveReplacePlaylist(id, s.name, next).catch(() =>
           setReplacePlaylists(prev => ({ ...prev, [id]: !next }))
         )
       },

--- a/src/web/frontend/src/lib/api.js
+++ b/src/web/frontend/src/lib/api.js
@@ -232,11 +232,11 @@ export async function saveEnrichMetadata(enabled) {
   if (!res.ok) throw new Error(await res.text())
 }
 
-export async function saveReplacePlaylist(name, replace) {
+export async function saveReplacePlaylist(id, name, replace) {
   const res = await apiFetch('/api/ui/config/replace-playlist', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, replace }),
+    body: JSON.stringify({ id, name, replace }),
   })
   if (!res.ok) throw new Error(await res.text())
 }


### PR DESCRIPTION
The **Save each run as new playlist** toggle in the playlist card flips back on its own and the setting is never written to `.env`.

### Cause

`saveReplacePlaylist()` posts `{name, replace}`:

```js
body: JSON.stringify({ name, replace }),
```

but `HandleSaveReplacePlaylist` resolves the playlist from `body.ID`:

```go
if def, ok := defs.PlaylistDefs[body.ID]; ok {
    ...
} else if defs.CustomIDRe.MatchString(body.ID) {
    ...
} else {
    http.Error(w, "unknown playlist name", http.StatusBadRequest)
    return
}
```

`body.ID` is always empty, so it matches neither branch and every request returns 400. `Settings.jsx` rolls back its optimistic update when the save rejects:

```js
saveReplacePlaylist(id, next).catch(() =>
  setReplacePlaylists(prev => ({ ...prev, [id]: !next }))
)
```

which is what makes the toggle appear to revert.

### Fix

Send `{id, name, replace}`, matching `saveSchedule()` — whose handler resolves the playlist with the same `PlaylistDefs` / `CustomIDRe` logic and already receives both fields. The handler needs `id` to look up the definition and `name` to derive the env prefix for custom playlists via `util.CustomEnvPrefix(body.Name)`.

### Testing

`npm run build` in `src/web/frontend` succeeds. Verified by inspection that `s.name` is in scope at the call site — it is the same value already passed to `saveSchedule(id, s.name, ...)` a few lines above, inside the same `scheduleProps(id)` closure.

Workaround for anyone hitting this before it merges: add `--replace-playlist=false` to the relevant `*_FLAGS` variable in `.env`, which is all the handler does.